### PR TITLE
brownbp1/alchemy_enable_dummy_atoms

### DIFF
--- a/include/chemistry/bcl_chemistry_fragment_alchemy.h
+++ b/include/chemistry/bcl_chemistry_fragment_alchemy.h
@@ -82,6 +82,9 @@ namespace bcl
       //! only mutate hydrogen atoms; if heavy atoms are made mutable, only consider their hydrogen(s)
       bool m_RestrictToBondedH;
 
+      //! the element type chosen during the mutate; updated internally
+      mutable ElementType m_ChosenElementType;
+
     public:
 
     //////////
@@ -187,6 +190,13 @@ namespace bcl
       //! @return the name used for this class in an object data label
       const std::string &GetAlias() const;
 
+      //! @brief returns the element type chosen during the mutate
+      //! @return the element type chosen during the mutate; if the
+      //! mutate has not yet been run, this will return an undefined
+      //! element type object, which is different than the element
+      //! type notated 'X' for undefined.
+      const ElementType &GetChosenElementType() const;
+
     ///////////////
     // operators //
     ///////////////
@@ -209,6 +219,11 @@ namespace bcl
     //////////////////////
     // helper functions //
     //////////////////////
+
+    private:
+
+      //! @brief set the chosen element type to which we are mutating
+      void SetChosenElement( const ElementType &ELEMENT_TYPE) const;
 
     protected:
 

--- a/source/chemistry/bcl_chemistry_fragment_alchemy.cpp
+++ b/source/chemistry/bcl_chemistry_fragment_alchemy.cpp
@@ -239,6 +239,16 @@ namespace bcl
       return s_name;
     }
 
+    //! @brief returns the element type chosen during the mutate
+    //! @return the element type chosen during the mutate; if the
+    //! mutate has not yet been run, this will return an undefined
+    //! element type object, which is different than the element
+    //! type notated 'X' for undefined.
+    const ElementType &FragmentAlchemy::GetChosenElementType() const
+    {
+      return m_ChosenElementType;
+    }
+
   ///////////////
   // operators //
   ///////////////
@@ -342,11 +352,18 @@ namespace bcl
           }
         }
 
+        // remember the chosen element type
+        SetChosenElement( m_AllowedElements( rand_ele_index));
+
         // is our atom in an aromatic ring?
         bool picked_atom_aromatic( picked_atom->CountNonValenceBondsWithProperty( ConfigurationalBondTypeData::e_IsAromatic, 1));
-        if( m_AllowedElements( rand_ele_index) == GetElementTypes().e_Hydrogen)
+        if( GetChosenElementType() == GetElementTypes().e_Hydrogen)
         {
           new_atom_type = GetAtomTypes().H_S;
+        }
+        else if( GetChosenElementType() == GetElementTypes().e_Undefined)
+        {
+          new_atom_type = GetAtomTypes().e_Undefined;
         }
         else
         {
@@ -362,7 +379,7 @@ namespace bcl
             BCL_MessageDbg( "n_nonh_e: " + util::Format()( n_nonh_e));
             PossibleAtomTypesForAtom available_atom_types
             (
-              m_AllowedElements( rand_ele_index),
+              GetChosenElementType(),
               n_nonh_e,
               n_current_bonds,
               util::IsDefined( m_FormalCharge) ? m_FormalCharge : picked_atom->GetCharge(),
@@ -460,6 +477,13 @@ namespace bcl
           }
         }
 
+        // skip geometry cleanup if we mutated into an undefined atom
+        if( GetChosenElementType() == GetElementTypes().e_Undefined)
+        {
+          BCL_MessageStd("Chosen element type from allowed element type list is Undefined; skipping fragment cleaning");
+          return math::MutateResult< FragmentComplete>( util::ShPtr< FragmentComplete>( new FragmentComplete( new_atom_vector, "")), *this);
+        }
+
         // for cleaning and optimizing the new molecule conformer
         FragmentMapConformer cleaner
         (
@@ -476,9 +500,8 @@ namespace bcl
 //          4
         );
 
-        // remove hydrogen atoms so ease burden on the isomorphism search during cleaning
-        static HydrogensHandler hydrogens_handler;
-        hydrogens_handler.Remove( new_atom_vector);
+        // remove hydrogen atoms to ease burden on the isomorphism search during cleaning
+        HydrogensHandler::Remove( new_atom_vector);
 
         // Standardize and return
         if( m_ScaffoldFragment.GetSize())
@@ -509,6 +532,13 @@ namespace bcl
     void FragmentAlchemy::SetRestrictions( const bool RESTRICT_TO_BOND_H)
     {
       m_RestrictToBondedH = RESTRICT_TO_BOND_H;
+    }
+
+
+    //! @brief set the chosen element type to which we are mutating
+    void FragmentAlchemy::SetChosenElement( const ElementType &ELEMENT_TYPE) const
+    {
+      m_ChosenElementType = ELEMENT_TYPE;
     }
 
   //////////////////////


### PR DESCRIPTION
This is a PR for a minor modification to the FragmentAlchemy class that enables it to perform alchemy to create undefined atoms in molecules. Undefined atoms are useful for pseudo-reaction chemistry during drug design. Previously, the allowed_element_types list included 'X' (for undefined) as a possible type; however, other logic related to choosing a correct atom type from the specified element, as well as the bits for molecule cleaning, prevented that flag from being functional. This has been corrected here.