### PR TITLE
Brownbp1/substructure biased flexible alignment

### DIFF
--- a/apps/internal/chemistry/bcl_app_conformer_generator.cpp
+++ b/apps/internal/chemistry/bcl_app_conformer_generator.cpp
@@ -881,10 +881,6 @@ namespace bcl
         }
       }
 
-      // add all the adjacent edges to our unique subgraph vertices
-//      storage::Set< size_t> all_adjacent_indices( cleaner.MapSubgraphAdjacentAtoms( target_subgraph_complement, 2) );
-//      moveable_atoms_set.InsertElements( all_adjacent_indices.Begin(), all_adjacent_indices.End());
-
       // collect unique atoms to be mobile
       MOLECULE.GetStoredPropertiesNonConst().SetMDLProperty("SampleByParts", linal::Vector< float>( moveable_atoms_set.Begin(), moveable_atoms_set.End()));
       return true;

--- a/apps/internal/chemistry/bcl_app_conformer_generator.h
+++ b/apps/internal/chemistry/bcl_app_conformer_generator.h
@@ -116,6 +116,8 @@ namespace bcl
 
       util::ShPtr< command::FlagInterface>                                        m_FixGeometryFlag;
 
+      util::ShPtr< command::FlagInterface>                                        m_FilterMetricFlag;
+
       //! obtains a dissimilarity
       mutable util::Implementation< chemistry::ConformationComparisonInterface>   m_Comparer;
 

--- a/apps/internal/chemistry/bcl_app_conformer_generator.h
+++ b/apps/internal/chemistry/bcl_app_conformer_generator.h
@@ -114,6 +114,8 @@ namespace bcl
 
       util::ShPtr< command::FlagInterface>                                        m_AlignByNonMobileFlag;
 
+      util::ShPtr< command::FlagInterface>                                        m_FixGeometryFlag;
+
       //! obtains a dissimilarity
       mutable util::Implementation< chemistry::ConformationComparisonInterface>   m_Comparer;
 
@@ -264,6 +266,19 @@ namespace bcl
         chemistry::FragmentEnsemble &ENSEMBLE,
         const chemistry::FragmentComplete &MOLECULE,
         const storage::Set< size_t> &ATOMS
+      ) const;
+
+      //! @brief function that identifies bad geometry atoms and adds them to the SampleByParts list
+      //! @param MOLECULE the molecule of interest whose conformations have to be sampled
+      //! @param MOLECULE_INDEX index of the molecule in the ensemble
+      //! @param OVERWRITE_SBP if true, ignore existing SampleByParts and make a new list of just the
+      //! atoms detected to contribute to bad geometry; if false, append bad geometry atoms to existing list
+      //! @return true if bad geometry atoms detected and added to SampleByParts list; false otherwise
+      bool DetectBadGeometry
+      (
+        chemistry::FragmentComplete &MOLECULE,
+        const size_t &MOLECULE_INDEX,
+        const bool OVERWRITE_SBP = true
       ) const;
 
       //! @brief controls output from the app of interest

--- a/apps/molecule/bcl_app_conformer_from_scaffold.cpp
+++ b/apps/molecule/bcl_app_conformer_from_scaffold.cpp
@@ -266,11 +266,11 @@ namespace bcl
             "this allows alternative poses to be discovered for symmetric molecules"
           )
         ),
-        m_FilterMetricFlag
+        m_UniqueFlag
         (
           new command::FlagStatic
           (
-            "filter_metric",
+            "unique",
             "distance between conformers required for a molecule to be unique; only applicable if 'find_all' is enabled",
             util::ShPtrVector< command::ParameterInterface>::Create
             (
@@ -306,7 +306,7 @@ namespace bcl
             "save_ensemble",
             "keep the ensemble of unique generated conformers; "
             "only applicable if 'find_all' is enabled; "
-            "occurs after application of 'filter_metric'"
+            "occurs after application of 'unique'"
           )
         )
     {
@@ -326,7 +326,7 @@ namespace bcl
           m_SolutionTypeFlag( PARENT.m_SolutionTypeFlag),
           m_SimilarityThresholdFlag( PARENT.m_SimilarityThresholdFlag),
           m_FindAllFlag( PARENT.m_FindAllFlag),
-          m_FilterMetricFlag( PARENT.m_FilterMetricFlag),
+          m_UniqueFlag( PARENT.m_UniqueFlag),
           m_SaveEnsembleFlag( PARENT.m_SaveEnsembleFlag)
     {
     }
@@ -368,7 +368,7 @@ namespace bcl
       sp_cmd->AddFlag( m_SolutionTypeFlag);
       sp_cmd->AddFlag( m_SimilarityThresholdFlag);
       sp_cmd->AddFlag( m_FindAllFlag);
-      sp_cmd->AddFlag( m_FilterMetricFlag);
+      sp_cmd->AddFlag( m_UniqueFlag);
       sp_cmd->AddFlag( m_SaveEnsembleFlag);
 
       // add default bcl parameters
@@ -471,23 +471,23 @@ namespace bcl
           confs.Sort( alignment_scorer.GetAlias());
 
           // filter to get unique poses
-          if ( m_FilterMetricFlag->GetFlag() && confs.GetSize() > 1)
+          if ( m_UniqueFlag->GetFlag() && confs.GetSize() > 1)
           {
-            util::Implementation<chemistry::ConformationComparisonInterface> filter_metric( m_FilterMetricFlag->GetFirstParameter()->GetValue());
+            util::Implementation<chemistry::ConformationComparisonInterface> unique( m_UniqueFlag->GetFirstParameter()->GetValue());
             chemistry::FragmentEnsemble uniq_confs;
 
             // add the first conformer
             auto conf_itr_i( confs.Begin());
             uniq_confs.PushBack( *conf_itr_i);
             for( ++conf_itr_i; conf_itr_i != confs.End(); ++conf_itr_i) {
-              float min_rmsd(std::numeric_limits<float>::max());
+              float min_rmsd( std::numeric_limits<float>::max());
               for( auto conf_itr_j( uniq_confs.Begin()); conf_itr_j != uniq_confs.End(); ++conf_itr_j)
               {
-                float rmsd( (*filter_metric)(*conf_itr_i, *conf_itr_j) );
+                float rmsd( (*unique)(*conf_itr_i, *conf_itr_j) );
                 min_rmsd = std::min(min_rmsd, rmsd);
               }
               // Check if min_rmsd is >= the threshold with respect to all previously observed conformers
-              bool meets_threshold( min_rmsd >= m_FilterMetricFlag->GetParameterList().LastElement()->GetNumericalValue<float>() );
+              bool meets_threshold( min_rmsd >= m_UniqueFlag->GetParameterList().LastElement()->GetNumericalValue<float>() );
               if( meets_threshold)
               {
                 uniq_confs.PushBack(*conf_itr_i);

--- a/apps/molecule/bcl_app_conformer_from_scaffold.cpp
+++ b/apps/molecule/bcl_app_conformer_from_scaffold.cpp
@@ -255,6 +255,59 @@ namespace bcl
               )
             )
           )
+        ),
+        m_FindAllFlag
+        (
+          new command::FlagStatic
+          (
+            "find_all",
+            "if this flag is provided, then follow the largest common substructure search "
+            "with a search for all subgraph isomorphisms between the common substructures; "
+            "this allows alternative poses to be discovered for symmetric molecules"
+          )
+        ),
+        m_FilterMetricFlag
+        (
+          new command::FlagStatic
+          (
+            "filter_metric",
+            "distance between conformers required for a molecule to be unique; only applicable if 'find_all' is enabled",
+            util::ShPtrVector< command::ParameterInterface>::Create
+            (
+              util::ShPtr< command::ParameterInterface>
+              (
+                new command::Parameter
+                (
+                  "rmsd_type",
+                  "method to use to find rmsd between conformers/poses",
+                  command::ParameterCheckSerializable( util::Implementation< chemistry::ConformationComparisonInterface>()),
+                  "SymmetryRealSpaceRMSD"
+                )
+              ),
+              util::ShPtr< command::ParameterInterface>
+              (
+                new command::Parameter
+                (
+                  "tolerance",
+                  "all conformers/poses must be at least this rmsd from the previously accepted pose; "
+                  "prior to evaluation, all alignment poses are scored with the MolAlign score; "
+                  "if you want additional local conformational heterogeneity, then run ConformerGenerator on the output of this app.",
+                  command::ParameterCheckRanged< float>( 0.0, std::numeric_limits< float>::max()),
+                  "1.0"
+                )
+              )
+            )
+          )
+        ),
+        m_SaveEnsembleFlag
+        (
+          new command::FlagStatic
+          (
+            "save_ensemble",
+            "keep the ensemble of unique generated conformers; "
+            "only applicable if 'find_all' is enabled; "
+            "occurs after application of 'filter_metric'"
+          )
         )
     {
     }
@@ -271,7 +324,10 @@ namespace bcl
           m_BondTypeFlag( PARENT.m_BondTypeFlag),
           m_MinSizeFlag( PARENT.m_MinSizeFlag),
           m_SolutionTypeFlag( PARENT.m_SolutionTypeFlag),
-          m_SimilarityThresholdFlag( PARENT.m_SimilarityThresholdFlag)
+          m_SimilarityThresholdFlag( PARENT.m_SimilarityThresholdFlag),
+          m_FindAllFlag( PARENT.m_FindAllFlag),
+          m_FilterMetricFlag( PARENT.m_FilterMetricFlag),
+          m_SaveEnsembleFlag( PARENT.m_SaveEnsembleFlag)
     {
     }
 
@@ -311,6 +367,9 @@ namespace bcl
       sp_cmd->AddFlag( m_MinSizeFlag);
       sp_cmd->AddFlag( m_SolutionTypeFlag);
       sp_cmd->AddFlag( m_SimilarityThresholdFlag);
+      sp_cmd->AddFlag( m_FindAllFlag);
+      sp_cmd->AddFlag( m_FilterMetricFlag);
+      sp_cmd->AddFlag( m_SaveEnsembleFlag);
 
       // add default bcl parameters
       command::GetAppDefaultFlags().AddDefaultCommandlineFlags( *sp_cmd);
@@ -323,9 +382,10 @@ namespace bcl
     //! @return error code - 0 for success
     int ConformerFromScaffold::Main() const
     {
+      BCL_MessageStd("Reading molecules...");
+
       // read in ensemble without hydrogen atoms to speedup substructure search
       io::IFStream input;
-      BCL_MessageStd("Reading input molecules...");
       io::File::MustOpenIFStream( input, m_InputFileFlag->GetFirstParameter()->GetValue());
       chemistry::FragmentEnsemble input_ensemble( input, sdf::e_Remove);
       io::File::CloseClearFStream( input);
@@ -333,7 +393,6 @@ namespace bcl
       BCL_Assert( ensemble_size, "Must have at least one molecule in the input ensemble. Exiting...\n");
 
       // read in the scaffold ensemble without hydrogen atoms to speedup substructure search
-      BCL_MessageStd("Reading scaffold molecules...");
       io::File::MustOpenIFStream( input, m_ScaffoldFileFlag->GetFirstParameter()->GetValue());
       const chemistry::FragmentEnsemble scaffold_ensemble( input, sdf::e_Remove);
       const storage::Vector< chemistry::FragmentComplete> scaffold_molecules( scaffold_ensemble.Begin(), scaffold_ensemble.End());
@@ -342,101 +401,33 @@ namespace bcl
       BCL_Assert( scaffold_ensemble_size, "Must have at least one molecule in the scaffold ensemble. Exiting...\n");
 
       // initialize output so that we can write as we go
-      io::OFStream output, output_similarity_failures, output_confgen_failures;
-      if( m_OutputFileFlag->GetFlag())
-      {
-        io::File::MustOpenOFStream( output, m_OutputFileFlag->GetFirstParameter()->GetValue());
-      }
-      if( m_OutputSimilarityFailureFileFlag->GetFlag())
-      {
-        io::File::MustOpenOFStream( output_similarity_failures, m_OutputSimilarityFailureFileFlag->GetFirstParameter()->GetValue());
-      }
-      if( m_OutputConfGenFailureFileFlag->GetFlag())
-      {
-        io::File::MustOpenOFStream( output_confgen_failures, m_OutputConfGenFailureFileFlag->GetFirstParameter()->GetValue());
-      }
+      InitializeOutputFiles();
 
       // Get the atom and bond type resolution for substructure comparisons
-      BCL_MessageStd("Initializing scaffold alignment object...");
-      graph::CommonSubgraphIsomorphismBase::SolutionType solution_type( graph::CommonSubgraphIsomorphismBase::SolutionType::e_Connected);
-      util::Implementation< chemistry::ConformationComparisonInterface> similarity_metric("LargestCommonSubstructureTanimoto");
-      if( m_SolutionTypeFlag->GetFirstParameter()->GetValue() == "Unconnected")
-      {
-        solution_type = graph::CommonSubgraphIsomorphismBase::SolutionType::e_Unconnected;
-        similarity_metric = util::Implementation< chemistry::ConformationComparisonInterface>("LargestCommonDisconnectedSubstructureTanimoto");
-      }
-      else if( m_SolutionTypeFlag->GetFirstParameter()->GetValue() == "GreedyUnconnected")
-      {
-        solution_type = graph::CommonSubgraphIsomorphismBase::SolutionType::e_GreedyUnconnected;
-        similarity_metric = util::Implementation< chemistry::ConformationComparisonInterface>("LargestCommonDisconnectedSubstructureTanimoto");
-      }
-      chemistry::FragmentAlignToScaffold ats
-      (
-        chemistry::ConformationGraphConverter::AtomComparisonTypeEnum( m_AtomTypeFlag->GetFirstParameter()->GetValue()),
-        chemistry::ConfigurationalBondTypeData::DataEnum( m_BondTypeFlag->GetFirstParameter()->GetValue()),
-        m_MinSizeFlag->GetFirstParameter()->GetNumericalValue< size_t>(),
-        solution_type
-      );
+      util::Implementation< chemistry::ConformationComparisonInterface> similarity_metric( InitializeSimilarityMetric());
+      graph::CommonSubgraphIsomorphismBase::SolutionType solution_type( InitializeSolutionType());
+      chemistry::FragmentAlignToScaffold ats( InitializeAlignmentObject( solution_type));
 
       // generate conformers for each input file based on template substructure
+      size_t total_confs( 0);
       BCL_MessageStd("Generating new conformer ensemble for input molecules...");
-      size_t mol_index( 0), success_count( 0), similarity_failure_count( 0), confgen_failure_count( 0);
       for
       (
           auto mol_itr( input_ensemble.Begin()), mol_itr_end( input_ensemble.End());
           mol_itr != mol_itr_end;
-          ++mol_itr, ++mol_index
+          ++mol_itr, ++m_MoleculeIndex
       )
       {
         // status update
-        if( mol_index % 100 == 0)
+        if( m_MoleculeIndex % 100 == 0)
         {
-          util::GetLogger().LogStatus( "Completed " + std::to_string( mol_index) + "/" + std::to_string( ensemble_size) + " molecules...\n");
+          util::GetLogger().LogStatus( "Completed " + std::to_string( m_MoleculeIndex) + "/" + std::to_string( ensemble_size) + " molecules...\n");
         }
 
-        // TODO: allow users to pass pre-computed similarity matrix to avoid computing similarity at this step
-        // compute the largest common substructure tanimoto similarity of current molecule to each scaffold
-        float best_similarity( 0.0);
-        size_t best_similarity_index( 0), scaffold_index( 0);
-        for
-        (
-            auto scaffold_itr( scaffold_molecules.Begin() ), scaffold_itr_end( scaffold_molecules.End());
-            scaffold_itr != scaffold_itr_end;
-            ++scaffold_itr, ++scaffold_index
-        )
+        // find the most similar molecule
+        storage::Pair< size_t, float> similarity_result( FindBestScaffoldBySimilarity( *mol_itr, scaffold_molecules, similarity_metric ) );
+        if( !util::IsDefined( similarity_result.First()))
         {
-          float current_similarity( ( *similarity_metric)( *mol_itr, *scaffold_itr ) );
-          BCL_MessageVrb( "Current similarity for molecule " + std::to_string( mol_index) + " against scaffold " + std::to_string( scaffold_index) + ": " + std::to_string( current_similarity));
-          if( current_similarity > best_similarity)
-          {
-            best_similarity = current_similarity;
-            best_similarity_index = scaffold_index;
-            if( best_similarity == 1.0)
-            {
-              break;
-            }
-          }
-        }
-
-        BCL_MessageVrb( "Best similarity for molecule " + std::to_string( mol_index) + " is against scaffold " + std::to_string( best_similarity_index) + ": " + std::to_string( best_similarity ) );
-        if
-        (
-            best_similarity < m_SimilarityThresholdFlag->GetFirstParameter()->GetNumericalValue< float>() ||
-            best_similarity > m_SimilarityThresholdFlag->GetParameterList().LastElement()->GetNumericalValue< float>()
-        )
-        {
-          if( m_OutputSimilarityFailureFileFlag->GetFlag())
-          {
-            mol_itr->WriteMDL( output_similarity_failures);
-          }
-
-          BCL_MessageVrb
-          (
-            "Molecule " + std::to_string( mol_index) + " failed similarity threshold requirement! "
-            "Maximum Tanimoto similarity to scaffold " + std::to_string( best_similarity_index)  +
-            " with a value of " + std::to_string( best_similarity)
-          );
-          ++similarity_failure_count;
           continue;
         }
 
@@ -444,77 +435,276 @@ namespace bcl
         descriptor::MoleculeSimilarity alignment_scorer
         (
           "PropertyFieldDistance",
-          chemistry::FragmentEnsemble( storage::List< chemistry::FragmentComplete>( 1, scaffold_molecules( best_similarity_index ) )
-          )
+          chemistry::FragmentEnsemble( storage::List< chemistry::FragmentComplete>( 1, scaffold_molecules( similarity_result.First())) )
         );
 
-        // generate the new conformer based on the most similar scaffold
-//        bool success(
-//          ats.ConformerFromScaffoldMCS
-//          (
-//            *mol_itr,
-//            scaffold_molecules( best_similarity_index),
-//            storage::Vector< size_t>(),
-//            storage::Vector< size_t>(),
-//            alignment_scorer
-//          )
-//        );
-        chemistry::FragmentEnsemble confs
-        (
-//          ats.ConformersFromScaffoldCS
-          ats.ConformersFromScaffoldIterative
-          (
-            *mol_itr,
-            scaffold_molecules( best_similarity_index) ,
-            storage::Vector< size_t>(),
-            storage::Vector< size_t>(),
-            alignment_scorer
-          )
-        );
-        BCL_Debug( confs.GetSize());
+        // build candidate conformers based on substructure comparisons to the most similar molecule in scaffolds list
+        chemistry::FragmentEnsemble confs( Run( *mol_itr, scaffold_molecules( similarity_result.First()), ats, alignment_scorer, m_FindAllFlag->GetFlag() ) );
         bool success( confs.GetSize());
-
         if( !success)
         {
           if( m_OutputConfGenFailureFileFlag->GetFlag())
           {
-            mol_itr->WriteMDL( output_confgen_failures);
+            mol_itr->WriteMDL( m_OutputConfgenFailures);
           }
 
           BCL_MessageVrb
           (
-            "Failed to generate conformer for molecule " + std::to_string( mol_index) +
-            " using scaffold " + std::to_string( best_similarity_index) +
-            " with a Tanimoto similarity of " + std::to_string( best_similarity)
+            "Failed to generate conformer for molecule " + std::to_string( m_MoleculeIndex) +
+            " using scaffold " + std::to_string( similarity_result.First()) +
+            " with a Tanimoto similarity of " + std::to_string( similarity_result.Second())
           );
-          ++confgen_failure_count;
+          ++m_ConfgenFailureCount;
         }
         else
         {
-//          mol_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_scaffold_filename", m_ScaffoldFileFlag->GetFirstParameter()->GetValue() );
-//          mol_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_scaffold_molecule_index", linal::Vector<float>(1, best_similarity_index) );
-//          mol_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_similarity_to_scaffold_molecule", linal::Vector< float>(1, best_similarity) );
-//          mol_itr->WriteMDL( output);
-          for( auto conf_itr( confs.Begin()), conf_itr_end( confs.End()); conf_itr != conf_itr_end; ++conf_itr)
+          // assign perfect alignment score if it is an identical molecule
+//          for( auto conf_itr( confs.Begin()), conf_itr_end( confs.End()); conf_itr != conf_itr_end; ++conf_itr)
+//          {
+//            if( similarity_result.Second() == 1.0)
+//            {
+//              conf_itr->GetStoredPropertiesNonConst().SetMDLProperty("alignment_scorer.GetAlias()", linal::Vector< float>(1, 0.0));
+//            }
+//          }
+
+          // lowest alignment score first
+          confs.Sort( alignment_scorer.GetAlias());
+
+          // filter to get unique poses
+          if ( m_FilterMetricFlag->GetFlag() && confs.GetSize() > 1)
           {
-            conf_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_scaffold_filename", m_ScaffoldFileFlag->GetFirstParameter()->GetValue() );
-            conf_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_scaffold_molecule_index", linal::Vector<float>(1, best_similarity_index) );
-            conf_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_similarity_to_scaffold_molecule", linal::Vector< float>(1, best_similarity) );
-            conf_itr->WriteMDL( output);
+            util::Implementation<chemistry::ConformationComparisonInterface> filter_metric( m_FilterMetricFlag->GetFirstParameter()->GetValue());
+            chemistry::FragmentEnsemble uniq_confs;
+
+            // add the first conformer
+            auto conf_itr_i( confs.Begin());
+            uniq_confs.PushBack( *conf_itr_i);
+            for( ++conf_itr_i; conf_itr_i != confs.End(); ++conf_itr_i) {
+              float min_rmsd(std::numeric_limits<float>::max());
+              for( auto conf_itr_j( uniq_confs.Begin()); conf_itr_j != uniq_confs.End(); ++conf_itr_j)
+              {
+                float rmsd( (*filter_metric)(*conf_itr_i, *conf_itr_j) );
+                min_rmsd = std::min(min_rmsd, rmsd);
+              }
+              // Check if min_rmsd is >= the threshold with respect to all previously observed conformers
+              bool meets_threshold( min_rmsd >= m_FilterMetricFlag->GetParameterList().LastElement()->GetNumericalValue<float>() );
+              if( meets_threshold)
+              {
+                uniq_confs.PushBack(*conf_itr_i);
+              }
+            }
+            confs = uniq_confs;
           }
-          ++success_count;
+
+          // save all remaining
+          auto confs_itr( confs.Begin());
+          if( m_SaveEnsembleFlag->GetFlag())
+          {
+            for( auto conf_itr_end( confs.End()); confs_itr != conf_itr_end; ++confs_itr)
+            {
+              confs_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_scaffold_filename", m_ScaffoldFileFlag->GetFirstParameter()->GetValue() );
+              confs_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_scaffold_molecule_index", linal::Vector<float>(1, similarity_result.First()) );
+              confs_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_similarity_to_scaffold_molecule", linal::Vector< float>(1, similarity_result.Second()) );
+              confs_itr->WriteMDL( m_Output);
+              ++total_confs;
+            }
+          }
+          else
+          {
+            confs_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_scaffold_filename", m_ScaffoldFileFlag->GetFirstParameter()->GetValue() );
+            confs_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_scaffold_molecule_index", linal::Vector<float>(1, similarity_result.First()) );
+            confs_itr->GetStoredPropertiesNonConst().SetMDLProperty( "ConformerFromScaffold_similarity_to_scaffold_molecule", linal::Vector< float>(1, similarity_result.Second()) );
+            confs_itr->WriteMDL( m_Output);
+            ++total_confs;
+          }
+          ++m_SuccessCount;
         }
       }
 
       // close the file stream
-      io::File::CloseClearFStream( output);
-      io::File::CloseClearFStream( output_similarity_failures);
-      io::File::CloseClearFStream( output_confgen_failures);
+      io::File::CloseClearFStream( m_Output);
+      io::File::CloseClearFStream( m_OutputSimilarityFailures);
+      io::File::CloseClearFStream( m_OutputConfgenFailures);
       BCL_MessageStd( "Summary report: ");
-      BCL_MessageStd( std::to_string( similarity_failure_count) + "/" + std::to_string( ensemble_size) + " molecules failed due to out of range similarity scores.");
-      BCL_MessageStd( std::to_string( confgen_failure_count) + "/" + std::to_string( ensemble_size) + " molecules failed during conformer generation.");
-      BCL_MessageStd( std::to_string( success_count) + "/" + std::to_string( ensemble_size) + " molecules were successful.");
+      BCL_MessageStd( std::to_string( m_SuccessCount) + "/" + std::to_string( ensemble_size) + " molecules were successful.");
+      BCL_MessageStd( std::to_string( m_SimilarityFailureCount) + "/" + std::to_string( ensemble_size) + " molecules failed due to out of range similarity scores.");
+      BCL_MessageStd( std::to_string( m_ConfgenFailureCount) + "/" + std::to_string( ensemble_size) + " molecules failed during conformer generation.");
+      BCL_MessageStd( std::to_string( total_confs) + " total conformers were saved.");
       return 0;
+    }
+
+    void ConformerFromScaffold::InitializeOutputFiles() const
+    {
+      BCL_MessageStd("Initializing output files...");
+      if( m_OutputFileFlag->GetFlag())
+      {
+        BCL_MessageStd("Conformers will be written to "
+          + util::Format()( m_OutputFileFlag->GetFirstParameter()->GetValue()));
+        io::File::MustOpenOFStream( m_Output, m_OutputFileFlag->GetFirstParameter()->GetValue());
+      }
+      if( m_OutputSimilarityFailureFileFlag->GetFlag())
+      {
+        BCL_MessageStd("Molecules with insufficient similarity to scaffold(s) will be written to "
+          + util::Format()( m_OutputSimilarityFailureFileFlag->GetFirstParameter()->GetValue()));
+        io::File::MustOpenOFStream( m_OutputSimilarityFailures, m_OutputSimilarityFailureFileFlag->GetFirstParameter()->GetValue());
+      }
+      if( m_OutputConfGenFailureFileFlag->GetFlag())
+      {
+        BCL_MessageStd("Molecules that fail during conformer generation will be written to "
+          + util::Format()( m_OutputConfGenFailureFileFlag->GetFirstParameter()->GetValue()));
+        io::File::MustOpenOFStream( m_OutputConfgenFailures, m_OutputConfGenFailureFileFlag->GetFirstParameter()->GetValue());
+      }
+    }
+
+    util::Implementation< chemistry::ConformationComparisonInterface> ConformerFromScaffold::InitializeSimilarityMetric() const
+    {
+      util::Implementation< chemistry::ConformationComparisonInterface> similarity_metric("LargestCommonSubstructureTanimoto");
+      if( m_SolutionTypeFlag->GetFirstParameter()->GetValue() == "Unconnected")
+      {
+        similarity_metric = util::Implementation< chemistry::ConformationComparisonInterface>("LargestCommonDisconnectedSubstructureTanimoto");
+      }
+      else if( m_SolutionTypeFlag->GetFirstParameter()->GetValue() == "GreedyUnconnected")
+      {
+        similarity_metric = util::Implementation< chemistry::ConformationComparisonInterface>("LargestCommonDisconnectedSubstructureTanimoto");
+      }
+      return similarity_metric;
+    }
+
+    graph::CommonSubgraphIsomorphismBase::SolutionType ConformerFromScaffold::InitializeSolutionType() const
+    {
+      graph::CommonSubgraphIsomorphismBase::SolutionType solution_type( graph::CommonSubgraphIsomorphismBase::SolutionType::e_Connected);
+      if( m_SolutionTypeFlag->GetFirstParameter()->GetValue() == "Unconnected")
+      {
+        solution_type = graph::CommonSubgraphIsomorphismBase::SolutionType::e_Unconnected;
+      }
+      else if( m_SolutionTypeFlag->GetFirstParameter()->GetValue() == "GreedyUnconnected")
+      {
+        solution_type = graph::CommonSubgraphIsomorphismBase::SolutionType::e_GreedyUnconnected;
+      }
+      return solution_type;
+    }
+
+    chemistry::FragmentAlignToScaffold ConformerFromScaffold::InitializeAlignmentObject
+    (
+      const graph::CommonSubgraphIsomorphismBase::SolutionType &SOLUTION_TYPE
+    ) const
+    {
+      return chemistry::FragmentAlignToScaffold
+      (
+        chemistry::ConformationGraphConverter::AtomComparisonTypeEnum( m_AtomTypeFlag->GetFirstParameter()->GetValue()),
+        chemistry::ConfigurationalBondTypeData::DataEnum( m_BondTypeFlag->GetFirstParameter()->GetValue()),
+        m_MinSizeFlag->GetFirstParameter()->GetNumericalValue< size_t>(),
+        SOLUTION_TYPE
+      );
+    }
+
+    storage::Pair< size_t, float> ConformerFromScaffold::FindBestScaffoldBySimilarity
+    (
+      const chemistry::FragmentComplete &MOLECULE,
+      const storage::Vector< chemistry::FragmentComplete> &SCAFFOLD_MOLECULES,
+      const util::Implementation< chemistry::ConformationComparisonInterface> &SIMILARITY_METRIC
+    ) const
+    {
+      // TODO: allow users to pass pre-computed similarity matrix to avoid computing similarity at this step
+      // compute the largest common substructure tanimoto similarity of current molecule to each scaffold
+      float best_similarity( 0.0);
+      size_t best_similarity_index( 0), scaffold_index( 0);
+      for
+      (
+          auto scaffold_itr( SCAFFOLD_MOLECULES.Begin() ), scaffold_itr_end( SCAFFOLD_MOLECULES.End());
+          scaffold_itr != scaffold_itr_end;
+          ++scaffold_itr, ++scaffold_index
+      )
+      {
+        float current_similarity( ( *SIMILARITY_METRIC)( MOLECULE, *scaffold_itr ) );
+        BCL_MessageVrb( "Current similarity for molecule "
+          + std::to_string( m_MoleculeIndex) + " against scaffold "
+          + std::to_string( scaffold_index) + ": "
+          + std::to_string( current_similarity)
+        );
+        if( current_similarity > best_similarity)
+        {
+          best_similarity = current_similarity;
+          best_similarity_index = scaffold_index;
+          if( best_similarity == 1.0)
+          {
+            break;
+          }
+        }
+      }
+      BCL_MessageVrb
+      (
+        "Best similarity for molecule " + std::to_string( m_MoleculeIndex)
+        + " is against scaffold " + std::to_string( best_similarity_index)
+        + ": " + std::to_string( best_similarity )
+      );
+      if
+      (
+          best_similarity < m_SimilarityThresholdFlag->GetFirstParameter()->GetNumericalValue< float>() ||
+          best_similarity > m_SimilarityThresholdFlag->GetParameterList().LastElement()->GetNumericalValue< float>()
+      )
+      {
+        if( m_OutputSimilarityFailureFileFlag->GetFlag())
+        {
+          MOLECULE.WriteMDL( m_OutputSimilarityFailures);
+        }
+
+        BCL_MessageVrb
+        (
+          "Molecule " + std::to_string( m_MoleculeIndex) + " failed similarity threshold requirement! "
+          "Maximum Tanimoto similarity to scaffold " + std::to_string( best_similarity_index)  +
+          " with a value of " + std::to_string( best_similarity)
+        );
+        ++m_SimilarityFailureCount;
+        return storage::Pair< size_t, float>( util::GetUndefinedSize_t(), util::GetUndefined< float>());
+      }
+      return storage::Pair< size_t, float>( best_similarity_index, best_similarity);
+    }
+
+    chemistry::FragmentEnsemble ConformerFromScaffold::Run
+    (
+      const chemistry::FragmentComplete &TARGET_MOLECULE,
+      const chemistry::FragmentComplete &SCAFFOLD_MOLECULE,
+      const chemistry::FragmentAlignToScaffold &ALIGNMENT_OBJECT,
+      const descriptor::MoleculeSimilarity &ALIGNMENT_SCORER,
+      const bool FIND_ALL
+    ) const
+    {
+      chemistry::FragmentEnsemble confs;
+      if( FIND_ALL)
+      {
+        confs = chemistry::FragmentEnsemble
+        (
+          ALIGNMENT_OBJECT.ConformersFromScaffoldIterative
+          (
+            TARGET_MOLECULE,
+            SCAFFOLD_MOLECULE,
+            storage::Vector< size_t>(),
+            storage::Vector< size_t>(),
+            ALIGNMENT_SCORER
+          )
+        );
+      }
+      else
+      {
+        // generate the new conformer based on the most similar scaffold
+        chemistry::FragmentComplete target_mol( TARGET_MOLECULE);
+        bool success(
+          ALIGNMENT_OBJECT.ConformerFromScaffoldMCS
+          (
+            target_mol,
+            SCAFFOLD_MOLECULE,
+            storage::Vector< size_t>(),
+            storage::Vector< size_t>(),
+            ALIGNMENT_SCORER
+          )
+        );
+        if( success)
+        {
+          confs = chemistry::FragmentEnsemble( storage::List< chemistry::FragmentComplete>(1, target_mol));
+        }
+      }
+      return confs;
     }
 
   //////////////////////

--- a/apps/molecule/bcl_app_conformer_from_scaffold.h
+++ b/apps/molecule/bcl_app_conformer_from_scaffold.h
@@ -102,8 +102,8 @@ namespace bcl
       // this allows alternative poses to be discovered for symmetric molecules
       util::ShPtr< command::FlagInterface> m_FindAllFlag;
 
-      // filter metric; only applicable if 'find_all' is enabled
-      util::ShPtr< command::FlagInterface> m_FilterMetricFlag;
+      // save only unique conformers from the final ensemble; only applicable if 'find_all' is enabled
+      util::ShPtr< command::FlagInterface> m_UniqueFlag;
 
       // keep the ensemble of unique generated conformers; only applicable if 'find_all' is enabled; occurs after application of 'filter_metric'
       util::ShPtr< command::FlagInterface> m_SaveEnsembleFlag;

--- a/include/chemistry/bcl_chemistry_conformation_graph_converter.h
+++ b/include/chemistry/bcl_chemistry_conformation_graph_converter.h
@@ -74,8 +74,10 @@ namespace bcl
         //! This is used to prevent combinatorial explosion when doing graph isomorphism searches with all hydrogens
         e_AtomTypeAndNumberHydrogensOnRingsAndDistinguishHydrogens,
         e_AtomTypeAndDistinguishHydrogens,
+        e_AtomTypeIsInRing,
         e_CIPPriorityHighToLow,            //!< Priority of the atoms
         e_CouldHaveSubstituents,           //!< Atoms that can be substituted
+        e_IsInRing,
         s_NumberAtomComparisonTypes
       };
 

--- a/include/chemistry/bcl_chemistry_fragment_align_to_scaffold.h
+++ b/include/chemistry/bcl_chemistry_fragment_align_to_scaffold.h
@@ -32,6 +32,7 @@
 #include "bcl_chemistry_fragment_ensemble.h"
 #include "find/bcl_find_pick_interface.h"
 #include "graph/bcl_graph_common_subgraph_isomorphism_base.h"
+#include "graph/bcl_graph_subgraph_isomorphism.h"
 #include "math/bcl_math_mutate_interface.h"
 #include "math/bcl_math_mutate_result.h"
 #include "storage/bcl_storage_vector.h"
@@ -78,6 +79,12 @@ namespace bcl
 
       // solution type for the isomorphism search
       graph::CommonSubgraphIsomorphismBase::SolutionType m_SolutionType;
+
+      // common subgraph isomorphism
+      mutable graph::CommonSubgraphIsomorphism< size_t, size_t> m_CommonSubgraphIsomorphism;
+
+      // subgraph isomorphism
+      mutable graph::SubgraphIsomorphism< size_t, size_t> m_SubgraphIsomorphism;
 
     public:
 
@@ -130,6 +137,12 @@ namespace bcl
 
       //! @brief return the solution type used for comparison
       const graph::CommonSubgraphIsomorphismBase::SolutionType &GetSolutionType() const;
+
+      //! @brief return the common subgraph isomorphism object
+      const graph::CommonSubgraphIsomorphism< size_t, size_t> GetCommonSubgraphIsomorphism() const;
+
+      //! @brief return the subgraph isomorphism object
+      const graph::SubgraphIsomorphism< size_t, size_t> GetSubgraphIsomorphism() const;
 
       //! @brief set the atom type used for comparison
       void SetAtomType( const ConformationGraphConverter::AtomComparisonType &ATOM_TYPE);
@@ -195,13 +208,60 @@ namespace bcl
       //! @param SCAFFOLD_MOL the molecule whose MCS with TARGET_MOL will be the core of the new conformation for TARGET_MOL
       //! @param TARGET_MOL_INDICES atoms in TARGET_MOL that will be searched for a common substructure
       //! @param SCAFFOLD_MOL_INDICES atoms in SCAFFOLD_MOL that will be searched for a common substructure
+      //! @param COMPARER if provided, a conformer will be selected that has the minimum value of the specified property
+      //! @param UPPER_BOUND upper bound on isomorphism search; if 0 then use EstimateUpperBounds; lower bound is default 1
       //! @return true if the conformer is generated successfully, false otherwise
-      bool GenerateConformerBasedOnScaffold
+      bool ConformerFromScaffoldMCS
       (
         FragmentComplete &TARGET_MOL,
         const FragmentComplete &SCAFFOLD_MOL,
         const storage::Vector< size_t> &TARGET_MOL_INDICES = storage::Vector< size_t>(),
-        const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES = storage::Vector< size_t>()
+        const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES = storage::Vector< size_t>(),
+        const descriptor::CheminfoProperty &COMPARER = descriptor::CheminfoProperty(),
+        const size_t UPPER_BOUND = 0
+      ) const;
+
+      //! @brief build an ensemble of conformers of the target molecule starting from the conformation of a shared substructure with a scaffold molecule
+      //! @details this function will generate one 3D conformer for each subgraph isomorphism up to a specified limit. Each conformer will be saved
+      //! with the corresponding SampleByParts atom indices as an MDL property so that additional conformers can be generated from this starting point
+      //! while keeping the common subgraph more-or-less fixed in space (barring any potential lever-arm effects). substructures are chosen in descending
+      //! order based on size.
+      //! @param TARGET_MOL the molecule for which a new conformer will be generated
+      //! @param SCAFFOLD_MOL the molecule whose MCS with TARGET_MOL will be the core of the new conformation for TARGET_MOL
+      //! @param TARGET_MOL_INDICES atoms in TARGET_MOL that will be searched for a common substructure
+      //! @param SCAFFOLD_MOL_INDICES atoms in SCAFFOLD_MOL that will be searched for a common substructure
+      //! @param COMPARER if provided, a conformer will be selected that has the minimum value of the specified property
+      //! @param N_MAX_SOLUTIONS maximum number of largest subgraphs to consider when generating conformers
+      //! @return an ensemble of conformers
+      FragmentEnsemble ConformersFromScaffoldCS
+      (
+        const FragmentComplete &TARGET_MOL,
+        const FragmentComplete &SCAFFOLD_MOL,
+        const storage::Vector< size_t> &TARGET_MOL_INDICES = storage::Vector< size_t>(),
+        const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES = storage::Vector< size_t>(),
+        const descriptor::CheminfoProperty &COMPARER = descriptor::CheminfoProperty(),
+        const size_t N_MAX_SOLUTIONS = 100
+      ) const;
+
+      //! @brief build an ensemble of conformers of the target molecule starting from the conformation of a shared substructure with a scaffold molecule;
+      //! iterates between ConformersFromScaffoldCS and ConformerFromScaffoldMCS reducing the size of the largest allowed subgraph progressively
+      //! @param TARGET_MOL the molecule for which a new conformer will be generated
+      //! @param SCAFFOLD_MOL the molecule whose MCS with TARGET_MOL will be the core of the new conformation for TARGET_MOL
+      //! @param TARGET_MOL_INDICES atoms in TARGET_MOL that will be searched for a common substructure
+      //! @param SCAFFOLD_MOL_INDICES atoms in SCAFFOLD_MOL that will be searched for a common substructure
+      //! @param COMPARER if provided, a conformer will be selected that has the minimum value of the specified property
+      //! @param N_MAX_SOLUTIONS maximum number of largest subgraphs to consider when generating conformers with ConformersFromScaffoldCS
+      //! @param N_ITERATIONS the number of iterations
+      //! @return an ensemble of conformers
+      FragmentEnsemble ConformersFromScaffoldIterative
+      (
+        const FragmentComplete &TARGET_MOL,
+        const FragmentComplete &SCAFFOLD_MOL,
+        const storage::Vector< size_t> &TARGET_MOL_INDICES = storage::Vector< size_t>(),
+        const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES = storage::Vector< size_t>(),
+        const descriptor::CheminfoProperty &COMPARER = descriptor::CheminfoProperty(),
+        const size_t N_MAX_SOLUTIONS = 100,
+        const size_t N_ITERATIONS = 1
       ) const;
 
       //////////////////////
@@ -212,10 +272,10 @@ namespace bcl
       static FragmentComplete ExtractFragmentByIndices( const FragmentComplete &MOLECULE, const storage::Vector< size_t> &INDICES);
 
       //! @brief get the maximum common substructure between two molecules
-      graph::CommonSubgraphIsomorphism< size_t, size_t> FindMaximumCommonSubstructure( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const;
+      graph::CommonSubgraphIsomorphism< size_t, size_t> FindCommonSubgraphIsomorphism( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const;
 
-      //! @brief get the common substructures between two molecules
-      storage::Vector< storage::Map< size_t, size_t> > FindAllCommonSubstructures( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const;
+      //! @brief get the common subgraphs between two molecules
+      graph::SubgraphIsomorphism< size_t, size_t> FindSubgraphIsomorphism( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const;
 
       //! @brief get a mutex
       static sched::Mutex &GetMutex();

--- a/include/chemistry/bcl_chemistry_fragment_align_to_scaffold.h
+++ b/include/chemistry/bcl_chemistry_fragment_align_to_scaffold.h
@@ -271,6 +271,17 @@ namespace bcl
       //! @brief extract a fragment from a molecule based on its indices
       static FragmentComplete ExtractFragmentByIndices( const FragmentComplete &MOLECULE, const storage::Vector< size_t> &INDICES);
 
+      //! @brief superimpose the coordinates of two molecules
+      //! @param TARGET_MOL the molecule to be aligned
+      //! @param SCAFFOLD_MOL the molecule to which TARGET_MOL will be aligned
+      static void Superimpose
+      (
+        FragmentComplete &TARGET_MOL,
+        const FragmentComplete &SCAFFOLD_MOL,
+        const storage::Vector< size_t> &TARGET_MOL_INDICES = storage::Vector< size_t>(),
+        const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES = storage::Vector< size_t>()
+      );
+
       //! @brief get the maximum common substructure between two molecules
       graph::CommonSubgraphIsomorphism< size_t, size_t> FindCommonSubgraphIsomorphism( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const;
 

--- a/include/chemistry/bcl_chemistry_fragment_map_conformer.h
+++ b/include/chemistry/bcl_chemistry_fragment_map_conformer.h
@@ -52,7 +52,7 @@ namespace bcl
     //! @brief Used to map the 3D coordinates of a derived structure to its parent
     //!
     //! @see @link example_chemistry_fragment_map_conformer.cpp @endlink
-    //! @author brownbp1, mendenjl
+    //! @author brownbp1
     //! @date Dec 13, 2019
     //!
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -120,6 +120,12 @@ namespace bcl
 
       //! set the moveable atom indices
       void SetMoveableAtomIndices( const storage::Vector< size_t> &ATOMS) { m_MoveableIndices = ATOMS;}
+
+      //! set the property scorer
+      void SetPropertyScorer( const descriptor::CheminfoProperty &PROPERTY) { m_PropertyScorer = PROPERTY;}
+
+      //! set whether to choose the best aligned conformer by the property scorer
+      void SetChooseBestAlignedConformer( const bool CHOICE) { m_ChooseBestAlignedConf = CHOICE;}
 
     //////////////////////////////////
     // construction and destruction //

--- a/include/descriptor/bcl_descriptor_molecule_similarity.h
+++ b/include/descriptor/bcl_descriptor_molecule_similarity.h
@@ -56,6 +56,9 @@ namespace bcl
       //! how to compare molecules
       util::Implementation< chemistry::ConformationComparisonInterface> m_Comparer;
 
+      //! name of the comparison object
+      std::string m_ComparerName;
+
       //! the molecules to compare to
       chemistry::FragmentEnsemble m_Molecules;
 
@@ -102,6 +105,14 @@ namespace bcl
       {
         return m_Molecules.GetSize();
       }
+
+      //! @brief return comparison implementation
+      //! @return the const comparison implementation
+      const util::Implementation< chemistry::ConformationComparisonInterface> GetComparer() const;
+
+      //! @brief return comparison implementation name
+      //! @return the const comparison implementation name
+      const std::string GetComparerName() const;
 
     ////////////////
     // operations //

--- a/scripts/machine_learning/descriptors/aa/AADescriptorsHelp.txt
+++ b/scripts/machine_learning/descriptors/aa/AADescriptorsHelp.txt
@@ -396,8 +396,6 @@ choose any  Sequence / Amino Acid Numeric descriptor :
           * Atom_Identity : 1, for any atom or molecule. The Atom_ prefix is purely for
             backwards-compatibility. In new descriptor files, the use of Constant(1) is preferred. Alias for :
             Constant(1)
-          * BondGirth : User-defined. Alias for :
-            DescriptorSum(2DAMax(steps=96,property=Atom_Identity,substitution_value=nan))
           * CovalentSurfaceArea : covalent surface area. Alias for : MoleculeSum(Atom_CovalentSurfaceArea)
           * CovalentVolume : covalent volume. Alias for : MoleculeSum(Atom_CovalentVolume)
           * EstCovSurfaceArea : Estimated covalent surface area (conformation independent). Alias for :
@@ -495,6 +493,8 @@ choose any  Sequence / Amino Acid Numeric descriptor :
             database; "MoleculeAtomEnvironmentMap(help)" shows internal options
           * MoleculeSimilarity : Searches for specified substructures within the query molecule. Returns 1 if
             a structure exists in the query molecule; "MoleculeSimilarity(help)" shows internal options
+          * MoleculeTotalToxicFragments : Returns true if the molecule contains a predicted mutagenic
+            substructure; false otherwise; "MoleculeTotalToxicFragments(help)" shows internal options
           * NAromaticRingHalogensMaxFragment : Determines the sum of the number of halogen substituents on
             aromatic rings in a molecule. Alternatively, identifies the aromatic ring with the most number of
             halogens and returns that count.; "NAromaticRingHalogensMaxFragment(help)" shows internal options
@@ -636,17 +636,9 @@ choose any  Sequence / Amino Acid Numeric descriptor :
             radii
           * Atom_FormalCharge : the formal charge of each atom
           * Atom_GyromagneticRatio : Retrieves the elemental GyromagneticRatio for each atom
-          * Atom_HSigmaChargeL : User-defined. Alias for : Multiply(Atom_SigmaChargeL,IsH)
-          * Atom_HVchargeL : User-defined. Alias for : Multiply(Atom_VchargeL,IsH)
           * Atom_HbondAcceptors : 1 for hydrogen bond acceptors (N and O), 0 for other elements
           * Atom_HbondDonors : 1 for hydrogen bond donors (NH and OH), 0 for others
-          * Atom_InAromaticRingIntersection : User-defined. Alias for :
-            GreaterEqual(lhs=BondTypeCount(property=IsAromatic,value=1),rhs=3)
-          * Atom_InRingIntersection : User-defined. Alias for :
-            GreaterEqual(lhs=BondTypeCount(property=IsInRing,value=1),rhs=3)
           * Atom_IonizationPotential : Retrieves the elemental IonizationPotential for each atom
-          * Atom_IsInAromaticRing : User-defined. Alias for :
-            GreaterEqual(lhs=BondTypeCount(property=IsAromatic,value=1),rhs=2)
           * Atom_IsSP : 1 for sp, -1 for non-sp non-terminal atoms, 0 for everything else
           * Atom_IsSP2 : 1 for sp2, -1 for non-sp2 non-terminal atoms, 0 for everything else
           * Atom_IsSP3 : 1 for sp3, -1 for non-sp3 non-terminal atoms, 0 for everything else
@@ -682,8 +674,6 @@ choose any  Sequence / Amino Acid Numeric descriptor :
           * Atom_SigmaValenceStateIonizationPotential : Retrieves the SigmaValenceStateIonizationPotential of
             desired atom
           * Atom_Stereocenters : 1 for R, -1 for S, 0 for achiral atoms, 2 for undefined chirality
-          * Atom_TernaryHBond : User-defined. Alias for :
-            Subtract(lhs=Atom_HbondAcceptors,rhs=Multiply(Constant(2),Atom_HbondDonors))
           * Atom_TopologicalPolarSurfaceArea : see Ertl, et. al. J. Med. Chem. 2000, 43, 3715
           * Atom_TotalCharge : Returns the total charge on an atom. Alias for :
             Add(Atom_SigmaCharge,Atom_PiCharge)
@@ -715,7 +705,6 @@ choose any  Sequence / Amino Acid Numeric descriptor :
           * IsF : Returns 1 for fluorine atoms, 0 for others. Alias for : Equal(AtomicNumbers,Constant(9))
           * IsH : Returns 1 for hydrogen atoms, 0 for heavy atoms. Alias for :
             Less(lhs=AtomicNumbers,rhs=Constant(1.5))
-          * IsHTernary : User-defined. Alias for : Add(Constant(-1),Multiply(IsH,Constant(2)))
           * IsHalogen : Returns 1 for atoms in main group 7 (F,Cl,Br,I,At,Uus). Alias for :
             Equal(Atom_MainGroup,Constant(7))
           * IsI : Returns 1 for iodine atoms, 0 for others. Alias for : Equal(AtomicNumbers,Constant(53))
@@ -796,8 +785,6 @@ choose any  Sequence / Amino Acid Numeric descriptor :
         Basic Implementations
           * Atom_Hydrophobic : User-defined. Alias for :
             Not(DescriptorSum(Abs(Partial(2DASign(property=PolarTernary,steps=3),indices(1,2,5,8)))))
-          * Atom_SigmaChargeL : User-defined. Alias for : Limit(Atom_SigmaCharge,max=0.25,min=-0.25)
-          * Atom_VchargeL : User-defined. Alias for : Limit(Atom_Vcharge,max=0.5,min=-0.5)
           
         Customizable Implementations
           * ForEach : Allows creation of a set of descriptors by substituting a user-specified set of values

--- a/scripts/machine_learning/descriptors/qsar/QSARDescriptorsHelp.txt
+++ b/scripts/machine_learning/descriptors/qsar/QSARDescriptorsHelp.txt
@@ -66,7 +66,7 @@ choose any  Molecule / Atom Numeric descriptor :
 
   Customizable Implementations
     * 3DInterHBondCode : Represents hydrogen bond interactions in relative distance and angle correlation bins
-      Default label : 3DInterHBondCode(step size=0.5,angle size=7214877045470555745,steps=14,misc property
+      Default label : 3DInterHBondCode(step size=0.5,angle size=94637393323400,steps=14,misc property
       id="",reference_conformer="",mol_a_atom_indices_filename="",mol_b_atom_indices_filename="")
       Parameters:
       <step size> size of each step in angstroms, default: "0.50", Any decimal (floating-point) value >= 0.01 <= 100
@@ -138,7 +138,7 @@ choose any  Molecule / Atom Numeric descriptor :
     estimates in J*K^-1*mol^-1, while the latter 4 indices are the PCA eigenvalue sums.
       Default label : EntropyQHA(sampler=SampleConformations(rotamer_library=bcl::chemistry::RotamerLibraryInterface,conformation_comparer=SymmetryRMSD(consider
       H=0,atom comparison=ElementType,bond comparison=FuzzyBondOrderAmideOrAromaticWithRingness,isomorphism
-      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01),local_ensemble="",global_ensemble="")
+      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01,sample_by_parts_mdl=SampleByParts,sample_by_parts_indices="",sample_by_parts_fragments=""),local_ensemble="",global_ensemble="")
       Parameters:
       <sampler> sample configurational space across dihedral bins, 
       default: "(conformation_comparer=bcl::chemistry::ConformationComparisonInterface,tolerance=0.0,generate_3D=0,relative_random_dihedral_change_weight=0.0,cluster=false,max_iterations=10000,max_conformations=1000)", sample conformations of molecules.
@@ -152,7 +152,7 @@ choose any  Molecule / Atom Numeric descriptor :
       SampleConformations(rotamer_library=bcl::chemistry::RotamerLibraryInterface,conformation_comparer=SymmetryRMSD(consider
           H=0,atom comparison=ElementType,bond comparison=FuzzyBondOrderAmideOrAromaticWithRingness,isomorphism
          
-      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01)
+      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01,sample_by_parts_mdl=SampleByParts,sample_by_parts_indices="",sample_by_parts_fragments="")
         Parameters:
         <rotamer_library> flag for rotamer library to use. Crystallographic open database is used by default, 
           default: "File",         choose any implementation of bcl::chemistry::RotamerLibraryInterface:
@@ -179,7 +179,7 @@ choose any  Molecule / Atom Numeric descriptor :
             AtomTypeAndComplexRingChirality, AtomTypeAndSymmetry, AtomTypeAndHasSymmetry,
             AtomTypeAndNumberHydrogens, AtomTypeAndNumberHydrogensOnRingAtoms,
             AtomTypeAndNumberHydrogensOnRingsAndDistinguishHydrogens, AtomTypeAndDistinguishHydrogens,
-            CIPPriorityHighToLow, CouldHaveSubstituents}
+            AtomTypeIsInRing, CIPPriorityHighToLow, CouldHaveSubstituents, IsInRing}
           <bond comparison> Used to decide whether bonds are similar enough to consider equivalent, 
             default: "FuzzyBondOrderAmideOrAromaticWithRingness", 
             Allowed values: {Identity, BondOrder, NumberOfElectrons, Conjugation, IsConjugated, IsAromatic,
@@ -211,11 +211,17 @@ choose any  Molecule / Atom Numeric descriptor :
           Any non-negative integer
         <cluster> Set to true to select up to max_conformations so as to maximize coverage of conformational space by
           performing greedy clustering on all returned conformations. This option should only be turned off when
-          generating boltzmann ensembles of conformers typically. Otherwise, better speed and rmsd recovery will result
-          just by decreasing # of iterations, default: "True", Any non-negative integer
+          generating boltzmann-like ensembles of conformers typically. Otherwise, better speed and rmsd recovery will
+          result just by decreasing # of iterations, default: "True", Any non-negative integer
         <relative_random_dihedral_change_weight> Weight for random dihededral changes relative to fragment based
           changes. This is desireable for exhaustive sampling or when parts of a fragment are very poorly represented
           in the fragment library, default: "0.0", Any decimal (floating-point) value
+        <sample_by_parts_mdl> MDL property from which to extract sample by parts atom indices from an SDF, 
+          default: "SampleByParts", any string
+        <sample_by_parts_indices> sample dihedral angles containing these atom indices (0-indexed) during conformer
+          generation, default: "", any string
+        <sample_by_parts_fragments> allow atoms that match these fragments in substructure comparisons to be sampled, 
+          default: "", any string
       <local_ensemble> input a pre-generated local ensemble, default: "", any string
       <global_ensemble> input a pre-generated global ensemble, default: "", any string
     * IsConstitutionDruglike : Returns 1 if the molecule is druglike and 0 otherwise
@@ -310,7 +316,7 @@ choose any  Molecule / Atom Numeric descriptor :
       distance=1,properties="",alignment
       options=PsiFlexField(properties="",property_weights(1),max_atom_distance_criterion=1,optimizing_weights=0,anchor_weight=0.01,linear_mismatch_penalty=0.01,heavy_mismatch_penalty_fraction=0.6,heavy_mismatch_penalty=2,weight_file_path="",data_file_name="",iterations=400,max_unimproved_steps=160,number_rigid_trajectories=5,number_outputs=1,align_to_scaffold=0,initial_rand_rotation=0,exclusion_indices_a="",exclusion_indices_b="",pose_tolerance=0.125,pose_score_threshold=2,flip_prob=0.06,big_rot_prob=0.06,bond_swap_prob=0.06,bond_align_prob=0.3,bond_align3_prob=0.2,bond_align_inf_prob=0.1,small_rot_prob=0.12,small_trans_prob=0.12,conf_swap_prob=0.06,potential_map_filename="",rigid_mol_b=1,conformer_pairs=100,top_pairs=3,filter_iterations=600,filter_limit=240,refinement_iterations=200,refinement_limit=80,number_flexible_trajectories=5,fraction_filtered_initially=0.25,fraction_filtered_iteratively=0.5,sample_conformers=SampleConformations(rotamer_library=bcl::chemistry::RotamerLibraryInterface,conformation_comparer=SymmetryRMSD(consider
       H=0,atom comparison=ElementType,bond comparison=FuzzyBondOrderAmideOrAromaticWithRingness,isomorphism
-      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01),conf_properties=""),property
+      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01,sample_by_parts_mdl=SampleByParts,sample_by_parts_indices="",sample_by_parts_fragments=""),conf_properties=""),property
       weights="")
       Parameters:
       <scaffold> the molecule to which the inputs are aligned, any existent file
@@ -329,7 +335,7 @@ choose any  Molecule / Atom Numeric descriptor :
       PsiFlexField(properties="",property_weights(1),max_atom_distance_criterion=1,optimizing_weights=0,anchor_weight=0.01,linear_mismatch_penalty=0.01,heavy_mismatch_penalty_fraction=0.6,heavy_mismatch_penalty=2,weight_file_path="",data_file_name="",iterations=400,max_unimproved_steps=160,number_rigid_trajectories=5,number_outputs=1,align_to_scaffold=0,initial_rand_rotation=0,exclusion_indices_a="",exclusion_indices_b="",pose_tolerance=0.125,pose_score_threshold=2,flip_prob=0.06,big_rot_prob=0.06,bond_swap_prob=0.06,bond_align_prob=0.3,bond_align3_prob=0.2,bond_align_inf_prob=0.1,small_rot_prob=0.12,small_trans_prob=0.12,conf_swap_prob=0.06,potential_map_filename="",rigid_mol_b=1,conformer_pairs=100,top_pairs=3,filter_iterations=600,filter_limit=240,refinement_iterations=200,refinement_limit=80,number_flexible_trajectories=5,fraction_filtered_initially=0.25,fraction_filtered_iteratively=0.5,sample_conformers=SampleConformations(rotamer_library=bcl::chemistry::RotamerLibraryInterface,conformation_comparer=SymmetryRMSD(consider
           H=0,atom comparison=ElementType,bond comparison=FuzzyBondOrderAmideOrAromaticWithRingness,isomorphism
          
-      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01),conf_properties="")
+      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01,sample_by_parts_mdl=SampleByParts,sample_by_parts_indices="",sample_by_parts_fragments=""),conf_properties="")
         Parameters:
         <properties> atom properties to consider, use multiply(Constant(X),property y) for weighting, 
           default:
@@ -432,7 +438,7 @@ choose any  Molecule / Atom Numeric descriptor :
             H=0,atom comparison=ElementType,bond comparison=FuzzyBondOrderAmideOrAromaticWithRingness,isomorphism
            
          
-      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01)
+      limit=1000),generate_3D=1,tolerance=0.25,max_cr_iterations=2,max_avg_clash=0.1,max_iterations=200,change_chirality=0,max_conformations=200,cluster=0,relative_random_dihedral_change_weight=0.01,sample_by_parts_mdl=SampleByParts,sample_by_parts_indices="",sample_by_parts_fragments="")
           Parameters:
           <rotamer_library> flag for rotamer library to use. Crystallographic open database is used by default, 
             default: "File",           choose any implementation of bcl::chemistry::RotamerLibraryInterface (already
@@ -453,7 +459,7 @@ choose any  Molecule / Atom Numeric descriptor :
               AtomTypeAndComplexRingChirality, AtomTypeAndSymmetry, AtomTypeAndHasSymmetry,
               AtomTypeAndNumberHydrogens, AtomTypeAndNumberHydrogensOnRingAtoms,
               AtomTypeAndNumberHydrogensOnRingsAndDistinguishHydrogens, AtomTypeAndDistinguishHydrogens,
-              CIPPriorityHighToLow, CouldHaveSubstituents}
+              AtomTypeIsInRing, CIPPriorityHighToLow, CouldHaveSubstituents, IsInRing}
             <bond comparison> Used to decide whether bonds are similar enough to consider equivalent, 
               default: "FuzzyBondOrderAmideOrAromaticWithRingness", 
               Allowed values: {Identity, BondOrder, NumberOfElectrons, Conjugation, IsConjugated, IsAromatic,
@@ -485,11 +491,17 @@ choose any  Molecule / Atom Numeric descriptor :
             Any non-negative integer
           <cluster> Set to true to select up to max_conformations so as to maximize coverage of conformational space by
             performing greedy clustering on all returned conformations. This option should only be turned off when
-            generating boltzmann ensembles of conformers typically. Otherwise, better speed and rmsd recovery will
+            generating boltzmann-like ensembles of conformers typically. Otherwise, better speed and rmsd recovery will
             result just by decreasing # of iterations, default: "True", Any non-negative integer
           <relative_random_dihedral_change_weight> Weight for random dihededral changes relative to fragment based
             changes. This is desireable for exhaustive sampling or when parts of a fragment are very poorly represented
             in the fragment library, default: "0.0", Any decimal (floating-point) value
+          <sample_by_parts_mdl> MDL property from which to extract sample by parts atom indices from an SDF, 
+            default: "SampleByParts", any string
+          <sample_by_parts_indices> sample dihedral angles containing these atom indices (0-indexed) during conformer
+            generation, default: "", any string
+          <sample_by_parts_fragments> allow atoms that match these fragments in substructure comparisons to be sampled,
+            default: "", any string
         <conf_properties> atom properties to consider, use multiply(Constant(X),property y) for weighting, 
           default: "(1)", Array of descriptors
           (anonymous) parameter: descriptors to concatenate, 
@@ -580,6 +592,10 @@ choose any  Molecule / Atom Numeric descriptor :
           * SymmetryRealSpaceRMSD : Calculates the root-mean-squared-deviation between two molecules that are
             identical onthe constitutional level, and whose atoms have already been aligned;
       "SymmetryRealSpaceRMSD(help)" shows internal options
+    * MoleculeTotalToxicFragments : Returns true if the molecule contains a predicted mutagenic substructure; false
+    otherwise
+      Parameter: <stabilizing_fragments> path to the SDF containing stabilizing fragments to consider, 
+      default: "rotamer_library/stabilizing_groups/stabilizing_groups.sdf.gz", any string
     * NAromaticRingHalogensMaxFragment : Determines the sum of the number of halogen substituents on aromatic rings in
     a molecule. Alternatively, identifies the aromatic ring with the most number of halogens and returns that count.
       Parameter: <allowed_halogens> halogen types that will be counted, default: "F Cl Br I", any string
@@ -611,8 +627,8 @@ choose any  Molecule / Atom Numeric descriptor :
       <atom comparison> atom data that is compared to determine whether atoms are equivalent, default: "AtomType", 
         Allowed values: {Identity, ElementType, AtomType, AtomTypeAndChirality, AtomTypeAndComplexRingChirality,
       AtomTypeAndSymmetry, AtomTypeAndHasSymmetry, AtomTypeAndNumberHydrogens, AtomTypeAndNumberHydrogensOnRingAtoms,
-      AtomTypeAndNumberHydrogensOnRingsAndDistinguishHydrogens, AtomTypeAndDistinguishHydrogens, CIPPriorityHighToLow,
-      CouldHaveSubstituents}
+      AtomTypeAndNumberHydrogensOnRingsAndDistinguishHydrogens, AtomTypeAndDistinguishHydrogens, AtomTypeIsInRing,
+      CIPPriorityHighToLow, CouldHaveSubstituents, IsInRing}
       <bond comparison> bond data that is compared, default: "BondOrderAmideOrAromaticWithRingness", 
         Allowed values: {Identity, BondOrder, NumberOfElectrons, Conjugation, IsConjugated, IsAromatic, IsAmide,
       IsInRing, BondOrderInRingOrAromatic, BondOrderOrAromatic, BondOrderAmideOrAromatic,
@@ -630,8 +646,8 @@ choose any  Molecule / Atom Numeric descriptor :
       <atom comparison> atom data that is compared to determine whether atoms are equivalent, default: "AtomType", 
         Allowed values: {Identity, ElementType, AtomType, AtomTypeAndChirality, AtomTypeAndComplexRingChirality,
       AtomTypeAndSymmetry, AtomTypeAndHasSymmetry, AtomTypeAndNumberHydrogens, AtomTypeAndNumberHydrogensOnRingAtoms,
-      AtomTypeAndNumberHydrogensOnRingsAndDistinguishHydrogens, AtomTypeAndDistinguishHydrogens, CIPPriorityHighToLow,
-      CouldHaveSubstituents}
+      AtomTypeAndNumberHydrogensOnRingsAndDistinguishHydrogens, AtomTypeAndDistinguishHydrogens, AtomTypeIsInRing,
+      CIPPriorityHighToLow, CouldHaveSubstituents, IsInRing}
       <bond comparison> bond data that is compared, default: "BondOrderAmideOrAromaticWithRingness", 
         Allowed values: {Identity, BondOrder, NumberOfElectrons, Conjugation, IsConjugated, IsAromatic, IsAmide,
       IsInRing, BondOrderInRingOrAromatic, BondOrderOrAromatic, BondOrderAmideOrAromatic,
@@ -895,7 +911,7 @@ choose any  Molecule / Atom Numeric descriptor :
     * 3DAPairRealSpaceConvolution : Relates the autocorrelations of two independent molecules
       Default label : 3DAPairRealSpaceConvolution(property=Molecule/Atom Numeric Descriptor,steps=20,step
       size=0.5,window size=4,weighting=bcl::descriptor::WindowWeightingInterface,misc property
-      id="",reference_conformer="",cutoff=1.09012e+27)
+      id="",reference_conformer="",cutoff=4.57986e-41)
       Parameters:
       <property> property over which to calculate the function, 
               choose any implementation of Molecule/Atom Numeric Descriptor (already listed)
@@ -915,7 +931,7 @@ choose any  Molecule / Atom Numeric descriptor :
       Default label : 3DAPairRealSpaceConvolutionAsymmetry(property_a=Molecule/Atom Numeric
       Descriptor,property_b=Molecule/Atom Numeric Descriptor,step size=0.5,window
       size=4,steps=20,weighting=bcl::descriptor::WindowWeightingInterface,misc property
-      id="",reference_conformer="",cutoff=0)
+      id="",reference_conformer="",cutoff=1.68514e+22)
       Parameters:
       <property_a> ligand property over which to calculate the function, 
               choose any implementation of Molecule/Atom Numeric Descriptor (already listed)

--- a/source/chemistry/bcl_chemistry_conformation_graph_converter.cpp
+++ b/source/chemistry/bcl_chemistry_conformation_graph_converter.cpp
@@ -56,8 +56,10 @@ namespace bcl
         "AtomTypeAndNumberHydrogensOnRingAtoms",
         "AtomTypeAndNumberHydrogensOnRingsAndDistinguishHydrogens",
         "AtomTypeAndDistinguishHydrogens",
+        "AtomTypeIsInRing",
         "CIPPriorityHighToLow",
         "CouldHaveSubstituents",
+        "IsInRing",
         GetStaticClassName< AtomComparisonType>()
       };
       return s_Names[ DATA];
@@ -540,10 +542,14 @@ namespace bcl
                  );
         case e_AtomTypeAndDistinguishHydrogens:
           return 9 * ATOM.GetAtomType().GetIndex();
+        case e_AtomTypeIsInRing:
+          return 9 * ATOM.GetAtomType().GetIndex() + ( ATOM.CountNonValenceBondsWithProperty( ConfigurationalBondTypeData::e_IsInRing, size_t( 1)) >= size_t( 1));
         case e_CIPPriorityHighToLow:
           return 0;
         case e_CouldHaveSubstituents:
           return ( ATOM.GetElementType()->GetMainGroup() != 6 && ATOM.GetElementType()->GetMainGroup() != 2);
+        case e_IsInRing:
+          return ATOM.CountNonValenceBondsWithProperty( ConfigurationalBondTypeData::e_IsInRing, size_t( 1)) >= size_t( 1);
         case s_NumberAtomComparisonTypes:
         default:
           return util::GetUndefined< size_t>();

--- a/source/chemistry/bcl_chemistry_fragment_align_to_scaffold.cpp
+++ b/source/chemistry/bcl_chemistry_fragment_align_to_scaffold.cpp
@@ -140,6 +140,18 @@ namespace bcl
       return m_SolutionType;
     }
 
+    //! @brief return the common subgraph isomorphism object
+    const graph::CommonSubgraphIsomorphism< size_t, size_t> FragmentAlignToScaffold::GetCommonSubgraphIsomorphism() const
+    {
+      return m_CommonSubgraphIsomorphism;
+    }
+
+    //! @brief return the subgraph isomorphism object
+    const graph::SubgraphIsomorphism< size_t, size_t> FragmentAlignToScaffold::GetSubgraphIsomorphism() const
+    {
+      return m_SubgraphIsomorphism;
+    }
+
     //! @brief set the atom type used for comparison
     void FragmentAlignToScaffold::SetAtomType( const ConformationGraphConverter::AtomComparisonType &ATOM_TYPE)
     {
@@ -193,7 +205,7 @@ namespace bcl
       util::SiPtrVector< const linal::Vector3D> mol_b_coords( scaffold_mol.GetHeavyAtomCoordinates()), mol_a_coords( target_mol.GetHeavyAtomCoordinates());
 
       // get the isomorphism between the target and scaffold
-      graph::CommonSubgraphIsomorphism< size_t, size_t> csi_substructure( FindMaximumCommonSubstructure( target_mol, scaffold_mol ) );
+      graph::CommonSubgraphIsomorphism< size_t, size_t> csi_substructure( FindCommonSubgraphIsomorphism( target_mol, scaffold_mol ) );
       csi_substructure.FindIsomorphism( csi_substructure.EstimateUpperBounds());
       storage::Map< size_t, size_t> isomorphism( csi_substructure.GetIsomorphism());
 
@@ -323,13 +335,17 @@ namespace bcl
     //! @param SCAFFOLD_MOL the molecule whose MCS with TARGET_MOL will be the core of the new conformation for TARGET_MOL
     //! @param TARGET_MOL_INDICES atoms in TARGET_MOL that will be searched for a common substructure
     //! @param SCAFFOLD_MOL_INDICES atoms in SCAFFOLD_MOL that will be searched for a common substructure
+    //! @param COMPARER if provided, a conformer will be selected that has the minimum value of the specified property
+    //! @param UPPER_BOUND upper bound on isomorphism search; if 0 then use EstimateUpperBounds; lower bound is default 1
     //! @return true if the conformer is generated successfully, false otherwise
-    bool FragmentAlignToScaffold::GenerateConformerBasedOnScaffold
+    bool FragmentAlignToScaffold::ConformerFromScaffoldMCS
     (
       FragmentComplete &TARGET_MOL,
       const FragmentComplete &SCAFFOLD_MOL,
       const storage::Vector< size_t> &TARGET_MOL_INDICES,
-      const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES
+      const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES,
+      const descriptor::CheminfoProperty &COMPARER,
+      const size_t UPPER_BOUND
     ) const
     {
       // extract the fragment for which the MCS search will be performed
@@ -337,15 +353,15 @@ namespace bcl
       FragmentComplete scaffold_mol( ExtractFragmentByIndices( SCAFFOLD_MOL, SCAFFOLD_MOL_INDICES));
 
       // get the isomorphism between the target and scaffold
-      graph::CommonSubgraphIsomorphism< size_t, size_t> csi_substructure( FindMaximumCommonSubstructure( target_mol, scaffold_mol ) );
-      csi_substructure.FindIsomorphism( csi_substructure.EstimateUpperBounds());
-      storage::Map< size_t, size_t> isomorphism( csi_substructure.GetIsomorphism( ) );
+      m_CommonSubgraphIsomorphism = graph::CommonSubgraphIsomorphism< size_t, size_t>( FindCommonSubgraphIsomorphism( target_mol, scaffold_mol ) );
+      m_CommonSubgraphIsomorphism.FindIsomorphism( UPPER_BOUND == 0 ? m_CommonSubgraphIsomorphism.EstimateUpperBounds( ) : UPPER_BOUND );
+      storage::Map< size_t, size_t> isomorphism( m_CommonSubgraphIsomorphism.GetIsomorphism( ) );
 
       // get the subgraph isomorphism for the target molecule
       graph::Subgraph< size_t, size_t> target_subgraph
       (
-        util::OwnPtr< const graph::ConstGraph< size_t, size_t> >( &csi_substructure.GetGraphA(), false),
-        csi_substructure.GetIsomorphism().GetKeysAsVector()
+        util::OwnPtr< const graph::ConstGraph< size_t, size_t> >( &m_CommonSubgraphIsomorphism.GetGraphA(), false),
+        m_CommonSubgraphIsomorphism.GetIsomorphism().GetKeysAsVector()
       );
 
       // alignment fails if there is no acceptable isomorphism
@@ -378,6 +394,7 @@ namespace bcl
         // add bad geometry atoms
         AtomVector< AtomComplete> temp_vec( target_atoms, TARGET_MOL.GetBondInfo());
         FragmentComplete temp_mol( temp_vec, TARGET_MOL.GetName());
+
         storage::Vector< size_t> bad_geo_atoms( temp_mol.GetAtomsWithBadGeometry());
         moveable_atoms_set.InsertElements( bad_geo_atoms.Begin(), bad_geo_atoms.End());
 
@@ -401,6 +418,8 @@ namespace bcl
         // collect unique atoms to be mobile
         moveable_atoms = storage::Vector< size_t>( moveable_atoms_set.Begin(), moveable_atoms_set.End());
         cleaner.SetMoveableAtomIndices( moveable_atoms);
+        cleaner.SetPropertyScorer( COMPARER);
+        cleaner.SetChooseBestAlignedConformer( true);
 
         // create cleaned molecule
         util::ShPtr< FragmentComplete> new_molecule
@@ -474,6 +493,260 @@ namespace bcl
       return false;
     }
 
+    //! @brief build an ensemble of conformers of the target molecule starting from the conformation of a shared substructure with a scaffold molecule
+    //! @details this function will generate one 3D conformer for each subgraph isomorphism up to a specified limit. Each conformer will be saved
+    //! with the corresponding SampleByParts atom indices as an MDL property so that additional conformers can be generated from this starting point
+    //! while keeping the common subgraph more-or-less fixed in space (barring any potential lever-arm effects). substructures are chosen in descending
+    //! order based on size.
+    //! @param TARGET_MOL the molecule for which a new conformer will be generated
+    //! @param SCAFFOLD_MOL the molecule whose MCS with TARGET_MOL will be the core of the new conformation for TARGET_MOL
+    //! @param TARGET_MOL_INDICES atoms in TARGET_MOL that will be searched for a common substructure
+    //! @param SCAFFOLD_MOL_INDICES atoms in SCAFFOLD_MOL that will be searched for a common substructure
+    //! @param COMPARER if provided, a conformer will be selected that has the minimum value of the specified property
+    //! @param N_MAX_SOLUTIONS maximum number of largest subgraphs to consider when generating conformers
+    //! @return an ensemble of conformers
+    FragmentEnsemble FragmentAlignToScaffold::ConformersFromScaffoldCS
+    (
+      const FragmentComplete &TARGET_MOL,
+      const FragmentComplete &SCAFFOLD_MOL,
+      const storage::Vector< size_t> &TARGET_MOL_INDICES,
+      const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES,
+      const descriptor::CheminfoProperty &COMPARER,
+      const size_t N_MAX_SOLUTIONS
+    ) const
+    {
+      // initialize output
+      FragmentEnsemble final_ensemble;
+
+      // extract the fragment for which the MCS search will be performed
+      FragmentComplete target_mol( ExtractFragmentByIndices( TARGET_MOL, TARGET_MOL_INDICES));
+      FragmentComplete scaffold_mol( ExtractFragmentByIndices( SCAFFOLD_MOL, SCAFFOLD_MOL_INDICES));
+
+      // get the isomorphism between the target and scaffold
+      m_SubgraphIsomorphism = graph::SubgraphIsomorphism< size_t, size_t>( FindSubgraphIsomorphism( target_mol, scaffold_mol ) );
+      m_SubgraphIsomorphism.FindAllIsomorphisms( );
+      storage::Vector< storage::Vector< size_t> > isomorphisms( m_SubgraphIsomorphism.GetIsomorphisms( ) );
+
+      // evaluate each isomorphism starting with the largest until we hit the limit
+      for( size_t iso_i( 0), n_iso( std::min( isomorphisms.GetSize(), N_MAX_SOLUTIONS)); iso_i < n_iso; ++iso_i)
+      {
+        const storage::Vector< size_t> &isomorphism( isomorphisms( iso_i));
+        if( isomorphism.GetSize() < m_MinIsoSize)
+        {
+          continue;
+        }
+
+        // get the subgraph isomorphism for the target molecule
+        storage::Vector< size_t> keys;
+        for( size_t a_i( 0), a_sz( isomorphism.GetSize()); a_i < a_sz; ++a_i)
+        {
+          keys.PushBack(a_i);
+        }
+        graph::Subgraph< size_t, size_t> target_subgraph
+        (
+          util::OwnPtr< const graph::ConstGraph< size_t, size_t> >( &m_SubgraphIsomorphism.GetSubgraph(), false),
+          keys
+        );
+
+        // for each atom in the isomorphism, set the target molecule atom coordinates to be those of the scaffold molecule
+        storage::Vector< sdf::AtomInfo> target_atoms( TARGET_MOL.GetAtomInfo( ) );
+        const storage::Vector< sdf::AtomInfo> &scaffold_atoms( SCAFFOLD_MOL.GetAtomInfo());
+        size_t a_i( 0);
+        for( auto iso_itr( isomorphism.Begin()), iso_itr_end( isomorphism.End()); iso_itr != iso_itr_end; ++iso_itr, ++a_i)
+        {
+          target_atoms( a_i).SetCoordinates( scaffold_atoms( *iso_itr).GetCoordinates());
+        }
+
+        // get inverted subgraph of the new mol
+        graph::Subgraph< size_t, size_t> target_subgraph_complement( target_subgraph.GetComplement( ) );
+        if( target_subgraph_complement.GetSize())
+        {
+          // generate a new 3D conformer without sampling the coordinates of the subgraph isomorphism
+          storage::Vector< size_t> moveable_atoms( target_subgraph_complement.GetVertexIndices());
+          storage::Set< size_t> moveable_atoms_set( moveable_atoms.Begin(), moveable_atoms.End());
+          FragmentMapConformer cleaner( "None", false, moveable_atoms);
+
+          // add all the adjacent edges to our unique subgraph vertices
+          storage::Set< size_t> all_adjacent_indices( cleaner.MapSubgraphAdjacentAtoms( target_subgraph_complement, 2) );
+          moveable_atoms_set.InsertElements( all_adjacent_indices.Begin(), all_adjacent_indices.End());
+
+          // add bad geometry atoms
+          AtomVector< AtomComplete> temp_vec( target_atoms, TARGET_MOL.GetBondInfo());
+          FragmentComplete temp_mol( temp_vec, TARGET_MOL.GetName());
+
+          storage::Vector< size_t> bad_geo_atoms( temp_mol.GetAtomsWithBadGeometry());
+          moveable_atoms_set.InsertElements( bad_geo_atoms.Begin(), bad_geo_atoms.End());
+
+          ConformationGraphConverter::t_AtomGraph molecule_graph( ConformationGraphConverter::CreateGraphWithAtoms( temp_mol));
+          FragmentSplitRings splitter( true, size_t( 3));
+          storage::List< storage::Vector< size_t> > ring_components( splitter.GetComponentVertices( temp_mol, molecule_graph));
+          storage::Vector< storage::Vector< size_t>> ring_components_vec( ring_components.Begin(), ring_components.End());
+          for( size_t ring_i( 0), n_rings( ring_components_vec.GetSize()); ring_i < n_rings; ++ring_i) {
+            storage::Set< size_t> ring_atoms( ring_components_vec( ring_i).Begin(), ring_components_vec( ring_i).End());
+            for( auto bad_geo_atoms_itr( bad_geo_atoms.Begin()), bad_geo_atoms_itr_end( bad_geo_atoms.End()); bad_geo_atoms_itr != bad_geo_atoms_itr_end; ++bad_geo_atoms_itr)
+            {
+              if (ring_atoms.Find( *bad_geo_atoms_itr) != ring_atoms.End())
+              {
+                // if found, then this ring contains bad geometry atoms and we need to add the whole ring to the moveable atoms set
+                moveable_atoms_set.InsertElements( ring_atoms.Begin(), ring_atoms.End());
+                break;
+              }
+            }
+          }
+
+          // collect unique atoms to be mobile
+          moveable_atoms = storage::Vector< size_t>( moveable_atoms_set.Begin(), moveable_atoms_set.End());
+          cleaner.SetMoveableAtomIndices( moveable_atoms);
+          cleaner.SetMoveableAtomIndices( moveable_atoms);
+          cleaner.SetPropertyScorer( COMPARER);
+          cleaner.SetChooseBestAlignedConformer( true);
+
+          // create cleaned molecule
+          util::ShPtr< FragmentComplete> new_molecule
+          (
+            cleaner.Clean
+            (
+              AtomVector< AtomComplete>( target_atoms, TARGET_MOL.GetBondInfo() ),
+              FragmentComplete(),
+              "None",
+              true
+            )
+          );
+
+          if( new_molecule.IsDefined())
+          {
+            // re-align the subgraph isomorphism to the desired coordinates; if the subgraph is not the largest substructure then
+            // it will not be re-positioned in real-space by default
+            util::SiPtrVector< const linal::Vector3D> scaffold_subgraph_coords( scaffold_mol.GetHeavyAtomCoordinates()), target_subraph_coords( new_molecule->GetHeavyAtomCoordinates());
+            target_subraph_coords.Reorder( keys);
+            scaffold_subgraph_coords.Reorder( isomorphism);
+
+            math::TransformationMatrix3D transform
+            (
+              quality::RMSD::SuperimposeCoordinates( scaffold_subgraph_coords, target_subraph_coords)
+            );
+
+            storage::Vector< sdf::AtomInfo> new_molecule_atom_vector( new_molecule->GetAtomInfo());
+            for
+            (
+                storage::Vector< sdf::AtomInfo>::iterator itr( new_molecule_atom_vector.Begin()),
+                itr_end( new_molecule_atom_vector.End());
+                itr != itr_end;
+                ++itr
+            )
+            {
+              linal::Vector3D coords( itr->GetCoordinates());
+              itr->SetCoordinates( coords.Transform( transform));
+            }
+
+            // add back the original properties to the re-aligned structure
+            AtomVector< AtomComplete> atoms_transformed( new_molecule_atom_vector, new_molecule->GetBondInfo());
+            FragmentComplete new_molecule_transformed( atoms_transformed, TARGET_MOL.GetName());
+            new_molecule_transformed.StoreProperties( TARGET_MOL);
+            new_molecule_transformed.GetStoredPropertiesNonConst().SetMDLProperty( "SampleByParts", moveable_atoms);
+            final_ensemble.PushBack(new_molecule_transformed);
+          }
+        }
+
+        // it is possible for the entire substructure to be contained within the scaffold such that there are no complement subgraph atoms
+        else
+        {
+          // clean atoms
+          AtomVector< AtomComplete> clean_atoms(
+            FragmentMapConformer::CleanAtoms
+            (
+              AtomVector< AtomComplete>( target_atoms, TARGET_MOL.GetBondInfo() ),
+              "None",
+              true
+            )
+          );
+          if( clean_atoms.GetSize())
+          {
+            FragmentComplete new_molecule( clean_atoms, TARGET_MOL.GetName());
+            new_molecule.StoreProperties( TARGET_MOL);
+            new_molecule.GetStoredPropertiesNonConst().SetMDLProperty( "SampleByParts", storage::Vector< size_t>() );
+            final_ensemble.PushBack(new_molecule);
+          }
+        }
+      }
+      return final_ensemble;
+    }
+
+    //! @brief build an ensemble of conformers of the target molecule starting from the conformation of a shared substructure with a scaffold molecule;
+    //! iterates between ConformersFromScaffoldCS and ConformerFromScaffoldMCS reducing the size of the largest allowed subgraph progressively
+    //! @param TARGET_MOL the molecule for which a new conformer will be generated
+    //! @param SCAFFOLD_MOL the molecule whose MCS with TARGET_MOL will be the core of the new conformation for TARGET_MOL
+    //! @param TARGET_MOL_INDICES atoms in TARGET_MOL that will be searched for a common substructure
+    //! @param SCAFFOLD_MOL_INDICES atoms in SCAFFOLD_MOL that will be searched for a common substructure
+    //! @param COMPARER if provided, a conformer will be selected that has the minimum value of the specified property
+    //! @param N_MAX_SOLUTIONS maximum number of largest subgraphs to consider when generating conformers with ConformersFromScaffoldCS
+    //! @param N_ITERATIONS the number of iterations
+    //! @return an ensemble of conformers
+    FragmentEnsemble FragmentAlignToScaffold::ConformersFromScaffoldIterative
+    (
+      const FragmentComplete &TARGET_MOL,
+      const FragmentComplete &SCAFFOLD_MOL,
+      const storage::Vector< size_t> &TARGET_MOL_INDICES,
+      const storage::Vector< size_t> &SCAFFOLD_MOL_INDICES,
+      const descriptor::CheminfoProperty &COMPARER,
+      const size_t N_MAX_SOLUTIONS,
+      const size_t N_ITERATIONS
+    ) const
+    {
+      // initialize output
+      FragmentEnsemble final_ensemble;
+
+      // if target_mol is a subgraph of scaffold_mol, then generate mapped conformers
+      FragmentEnsemble subgraph_iso_ens;
+
+      size_t upper_bound( 0), increment( 1);
+      for( size_t iteration( 0); iteration < N_ITERATIONS; ++iteration, ++increment)
+      {
+        FragmentComplete target_mol( TARGET_MOL); // always do the MCS search from starting target molecule
+        AtomVector< AtomComplete> target_mol_atoms( TARGET_MOL.GetAtomVector()), scaffold_mol_atoms( SCAFFOLD_MOL.GetAtomVector());
+
+        // try to generate a mapped conformer of the common subgraph between the target_mol and the scaffold_mol
+        bool common_subgraph_success
+        (
+          ConformerFromScaffoldMCS( target_mol, SCAFFOLD_MOL, TARGET_MOL_INDICES, SCAFFOLD_MOL_INDICES, COMPARER) //, upper_bound)
+        );
+        if( common_subgraph_success)
+        {
+          final_ensemble.PushBack(target_mol);
+        }
+
+        // get a molecule composed only of the common subgraph atoms from target_mol
+        storage::Vector< size_t> csi_iso_a( m_CommonSubgraphIsomorphism.GetIsomorphism().GetKeysAsVector() );
+        storage::Vector< size_t> csi_iso_b( m_CommonSubgraphIsomorphism.GetIsomorphism().GetMappedValues() );
+        target_mol_atoms.Reorder(csi_iso_a );
+        scaffold_mol_atoms.Reorder(csi_iso_b);
+        FragmentComplete target_mol_prime( target_mol_atoms, ""), scaffold_mol_prime( scaffold_mol_atoms, "");
+        graph::CommonSubgraphIsomorphism< size_t, size_t> csi_prime_target( FindCommonSubgraphIsomorphism( target_mol_prime, target_mol));
+        graph::CommonSubgraphIsomorphism< size_t, size_t> csi_prime_scaffold( FindCommonSubgraphIsomorphism( scaffold_mol_prime, SCAFFOLD_MOL));
+
+        // look for all subgraph isomorphisms of target csi mol against the original scaffold
+        subgraph_iso_ens = ConformersFromScaffoldCS( target_mol_prime, scaffold_mol_prime, storage::Vector< size_t>(), storage::Vector< size_t>(), COMPARER, N_MAX_SOLUTIONS);
+        if( subgraph_iso_ens.GetSize())
+        {
+
+          // rebuild target molecule using each aligned subgraph isomorphism as a scaffold
+          for( auto mol_itr( subgraph_iso_ens.Begin()), mol_itr_end( subgraph_iso_ens.End()); mol_itr != mol_itr_end; ++mol_itr)
+          {
+            FragmentComplete temp_target_mol( TARGET_MOL);
+            bool success
+            (
+              ConformerFromScaffoldMCS( temp_target_mol, *mol_itr, TARGET_MOL_INDICES, storage::Vector< size_t>(), COMPARER)
+            );
+            if( success)
+            {
+              final_ensemble.PushBack( temp_target_mol);
+            }
+          }
+        }
+      }
+      return final_ensemble;
+    }
+
     //////////////////////
     // helper functions //
     //////////////////////
@@ -491,7 +764,7 @@ namespace bcl
     }
 
     //! @brief get the maximum common substructure between two molecules
-    graph::CommonSubgraphIsomorphism< size_t, size_t> FragmentAlignToScaffold::FindMaximumCommonSubstructure( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const
+    graph::CommonSubgraphIsomorphism< size_t, size_t> FragmentAlignToScaffold::FindCommonSubgraphIsomorphism( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const
     {
       const ConformationGraphConverter arbitrary_graph_converter( m_AtomType, m_BondType, true );
       graph::ConstGraph< size_t, size_t>
@@ -503,20 +776,18 @@ namespace bcl
       return csi_substructure;
     }
 
-    //! @brief get the common substructures between two molecules
-//    storage::Vector< storage::Map< size_t, size_t> > FragmentAlignToScaffold::FindAllCommonSubstructures( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const
-//    {
-//      const ConformationGraphConverter arbitrary_graph_converter( m_AtomType, m_BondType, true);
-//      graph::ConstGraph< size_t, size_t>
-//          mol_a_graph( arbitrary_graph_converter( MOL_A)),
-//          mol_b_graph( arbitrary_graph_converter( MOL_B));
-//
-//      graph::SubgraphIsomorphism< size_t, size_t> csi_substructure;
-//      csi_substructure.SetGraphs( mol_a_graph, mol_b_graph);
-//      csi_substructure.FindAllIsomorphisms();  // TODO add options for these
-//      storage::Vector< storage::Map< size_t, size_t> >isomorphisms( csi_substructure.GetIsomorphisms( ) );
-//      return isomorphisms;
-//    }
+    //! @brief get the common subgraphs between two molecules
+    graph::SubgraphIsomorphism< size_t, size_t> FragmentAlignToScaffold::FindSubgraphIsomorphism( const FragmentComplete &MOL_A, const FragmentComplete &MOL_B) const
+    {
+      const ConformationGraphConverter arbitrary_graph_converter( m_AtomType, m_BondType, true );
+      graph::ConstGraph< size_t, size_t>
+          mol_a_graph( arbitrary_graph_converter( MOL_A)),
+          mol_b_graph( arbitrary_graph_converter( MOL_B));
+
+      graph::SubgraphIsomorphism< size_t, size_t> csi_substructure;
+      csi_substructure.SetGraphs( mol_a_graph, mol_b_graph);
+      return csi_substructure;
+    }
 
     // initialize static
     sched::Mutex &FragmentAlignToScaffold::GetMutex()

--- a/source/chemistry/bcl_chemistry_fragment_align_to_scaffold.cpp
+++ b/source/chemistry/bcl_chemistry_fragment_align_to_scaffold.cpp
@@ -350,7 +350,9 @@ namespace bcl
     {
       // extract the fragment for which the MCS search will be performed
       FragmentComplete target_mol( ExtractFragmentByIndices( TARGET_MOL, TARGET_MOL_INDICES));
+      target_mol.StoreProperties( TARGET_MOL);
       FragmentComplete scaffold_mol( ExtractFragmentByIndices( SCAFFOLD_MOL, SCAFFOLD_MOL_INDICES));
+      scaffold_mol.StoreProperties( SCAFFOLD_MOL);
 
       // get the isomorphism between the target and scaffold
       m_CommonSubgraphIsomorphism = graph::CommonSubgraphIsomorphism< size_t, size_t>( FindCommonSubgraphIsomorphism( target_mol, scaffold_mol ) );
@@ -402,7 +404,8 @@ namespace bcl
         FragmentSplitRings splitter( true, size_t( 3));
         storage::List< storage::Vector< size_t> > ring_components( splitter.GetComponentVertices( temp_mol, molecule_graph));
         storage::Vector< storage::Vector< size_t>> ring_components_vec( ring_components.Begin(), ring_components.End());
-        for( size_t ring_i( 0), n_rings( ring_components_vec.GetSize()); ring_i < n_rings; ++ring_i) {
+        for( size_t ring_i( 0), n_rings( ring_components_vec.GetSize()); ring_i < n_rings; ++ring_i)
+        {
           storage::Set< size_t> ring_atoms( ring_components_vec( ring_i).Begin(), ring_components_vec( ring_i).End());
           for( auto bad_geo_atoms_itr( bad_geo_atoms.Begin()), bad_geo_atoms_itr_end( bad_geo_atoms.End()); bad_geo_atoms_itr != bad_geo_atoms_itr_end; ++bad_geo_atoms_itr)
           {
@@ -463,6 +466,7 @@ namespace bcl
           AtomVector< AtomComplete> atoms_transformed( new_molecule_atom_vector, new_molecule->GetBondInfo());
           FragmentComplete new_molecule_transformed( atoms_transformed, TARGET_MOL.GetName());
           new_molecule_transformed.StoreProperties( TARGET_MOL);
+          new_molecule_transformed.StoreProperties( *new_molecule);
           new_molecule_transformed.GetStoredPropertiesNonConst().SetMDLProperty( "SampleByParts", moveable_atoms);
           TARGET_MOL = new_molecule_transformed;
           return true;
@@ -485,6 +489,8 @@ namespace bcl
         {
           FragmentComplete new_molecule( clean_atoms, TARGET_MOL.GetName());
           new_molecule.StoreProperties( TARGET_MOL);
+          linal::Vector<float> alignment_score( COMPARER->SumOverObject( new_molecule) );
+          new_molecule.GetStoredPropertiesNonConst().SetMDLProperty( COMPARER->GetAlias(), alignment_score);
           new_molecule.GetStoredPropertiesNonConst().SetMDLProperty( "SampleByParts", storage::Vector< size_t>() );
           TARGET_MOL = new_molecule;
           return true;
@@ -520,7 +526,9 @@ namespace bcl
 
       // extract the fragment for which the MCS search will be performed
       FragmentComplete target_mol( ExtractFragmentByIndices( TARGET_MOL, TARGET_MOL_INDICES));
+      target_mol.StoreProperties( TARGET_MOL);
       FragmentComplete scaffold_mol( ExtractFragmentByIndices( SCAFFOLD_MOL, SCAFFOLD_MOL_INDICES));
+      scaffold_mol.StoreProperties( SCAFFOLD_MOL);
 
       // get the isomorphism between the target and scaffold
       m_SubgraphIsomorphism = graph::SubgraphIsomorphism< size_t, size_t>( FindSubgraphIsomorphism( target_mol, scaffold_mol ) );
@@ -643,8 +651,9 @@ namespace bcl
             AtomVector< AtomComplete> atoms_transformed( new_molecule_atom_vector, new_molecule->GetBondInfo());
             FragmentComplete new_molecule_transformed( atoms_transformed, TARGET_MOL.GetName());
             new_molecule_transformed.StoreProperties( TARGET_MOL);
+            new_molecule_transformed.StoreProperties( *new_molecule);
             new_molecule_transformed.GetStoredPropertiesNonConst().SetMDLProperty( "SampleByParts", moveable_atoms);
-            final_ensemble.PushBack(new_molecule_transformed);
+            final_ensemble.PushBack( new_molecule_transformed);
           }
         }
 
@@ -664,8 +673,10 @@ namespace bcl
           {
             FragmentComplete new_molecule( clean_atoms, TARGET_MOL.GetName());
             new_molecule.StoreProperties( TARGET_MOL);
+            linal::Vector<float> alignment_score( COMPARER->SumOverObject( new_molecule) );
+            new_molecule.GetStoredPropertiesNonConst().SetMDLProperty( COMPARER->GetAlias(), alignment_score);
             new_molecule.GetStoredPropertiesNonConst().SetMDLProperty( "SampleByParts", storage::Vector< size_t>() );
-            final_ensemble.PushBack(new_molecule);
+            final_ensemble.PushBack( new_molecule);
           }
         }
       }

--- a/source/chemistry/bcl_chemistry_fragment_map_conformer.cpp
+++ b/source/chemistry/bcl_chemistry_fragment_map_conformer.cpp
@@ -400,10 +400,10 @@ namespace bcl
             for( auto conf_itr( conf_ens->Begin()), conf_itr_end( conf_ens->End()); conf_itr != conf_itr_end; ++conf_itr)
             {
               linal::Vector<float> alignment_score( m_PropertyScorer->SumOverObject( *conf_itr));
-              conf_itr->GetStoredPropertiesNonConst().SetMDLProperty("PropertyFieldDistance", alignment_score);
+              conf_itr->GetStoredPropertiesNonConst().SetMDLProperty( m_PropertyScorer->GetAlias(), alignment_score);
             }
             // output best by MolAlign score
-            conf_ens->Sort( "PropertyFieldDistance");
+            conf_ens->Sort( m_PropertyScorer->GetAlias());
             gen_mol_3d_sp = util::CloneToShPtr( conf_ens->GetMolecules().FirstElement());
           }
         }
@@ -548,7 +548,7 @@ namespace bcl
       }
       else
       {
-        BCL_MessageStd( "Skipping drug-likeness filter!");
+        BCL_MessageVrb( "Skipping drug-likeness filter!");
       }
       return new_mol.GetAtomVector();
     }

--- a/source/chemistry/bcl_chemistry_fragment_map_conformer.cpp
+++ b/source/chemistry/bcl_chemistry_fragment_map_conformer.cpp
@@ -255,7 +255,7 @@ namespace bcl
       util::ShPtr< FragmentComplete> gen_mol_3d_sp;
 
       // conformer-dependent score-based refinement
-      if( m_PropertyScorer.IsDefined())
+      if( m_PropertyScorer.IsDefined() && !m_ChooseBestAlignedConf)
       {
         // make conformers
         static FragmentMakeConformers make_confs
@@ -344,12 +344,13 @@ namespace bcl
           static FragmentMakeConformers make_confs
           (
             rotamer_library,
-            "SymmetryRMSD",
-            0.25,
+            "",
+            0.25,  // was 0.25
             true,
-            2000,
+            2000,   // was 2000
             0.1,
-            true,
+            false,  // was true
+            false,
             false
           );
           if( m_MoveableIndices.IsEmpty())
@@ -361,8 +362,8 @@ namespace bcl
             conf_ens = make_confs.MakeConformers( new_mol); // make a single new conformer
           }
 
-          // bail if no conformers could be generated
-          if( !conf_ens.IsDefined())
+          // bail if no conformers could be generated and if input conformer is undefined
+          if( !conf_ens.IsDefined() && !gen_mol_3d_sp.IsDefined())
           {
             BCL_MessageStd( "Could not generate a valid conformer ensemble, returning null");
             return util::ShPtr< FragmentComplete>();
@@ -392,6 +393,18 @@ namespace bcl
             {
               gen_mol_3d_sp = util::CloneToShPtr( new_mol);
             }
+          }
+          // score the ensemble without re-alignment and choose best by score
+          else if( conf_ens->GetSize() && m_PropertyScorer.IsDefined())
+          {
+            for( auto conf_itr( conf_ens->Begin()), conf_itr_end( conf_ens->End()); conf_itr != conf_itr_end; ++conf_itr)
+            {
+              linal::Vector<float> alignment_score( m_PropertyScorer->SumOverObject( *conf_itr));
+              conf_itr->GetStoredPropertiesNonConst().SetMDLProperty("PropertyFieldDistance", alignment_score);
+            }
+            // output best by MolAlign score
+            conf_ens->Sort( "PropertyFieldDistance");
+            gen_mol_3d_sp = util::CloneToShPtr( conf_ens->GetMolecules().FirstElement());
           }
         }
         // just make a single conformer and choose by conf score

--- a/source/descriptor/bcl_descriptor_molecule_similarity.cpp
+++ b/source/descriptor/bcl_descriptor_molecule_similarity.cpp
@@ -64,6 +64,7 @@ namespace bcl
       m_Molecules( MOLECULES),
       m_Filename( std::string())
     {
+      m_ComparerName = m_Comparer->GetAlias();
     }
 
     //! @brief virtual copy constructor
@@ -87,8 +88,22 @@ namespace bcl
     //! @return name of the property as string
     const std::string &MoleculeSimilarity::GetAlias() const
     {
-      static const std::string s_name( "MoleculeSimilarity");
+      static const std::string s_name( GetComparerName().empty() ? "MoleculeSimilarity" : GetComparerName());
       return s_name;
+    }
+
+    //! @brief return comparison implementation
+    //! @return the const comparison implementation
+    const util::Implementation< chemistry::ConformationComparisonInterface> MoleculeSimilarity::GetComparer() const
+    {
+      return m_Comparer;
+    }
+
+    //! @brief return comparison implementation name
+    //! @return the const comparison implementation name
+    const std::string MoleculeSimilarity::GetComparerName() const
+    {
+      return m_ComparerName;
     }
 
   ////////////////


### PR DESCRIPTION
Created an application an ancillary code that allows a conformer of molecule A to be generated based on an existing conformer of molecule B. The general idea is that you calculate substructure similarity and if it is within user-specified limits, then you map the coordinates of the common subgraph of A to the coordinates of those atoms in B. Then you set as mobile the complement atoms in A and run the conformer generator on the mobile atoms/rotamers. There are a variety of geometry-correcting features involved. 